### PR TITLE
Add "Swimlane by"

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "kanban-bases-view",
 	"name": "Kanban Bases View",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"minAppVersion": "1.0.0",
 	"description": "A kanban-style drag-and-drop custom view for Bases.",
 	"author": "I. Welch Canavan",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "kanban-bases-view",
-	"version": "0.4.4",
+	"version": "0.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "kanban-bases-view",
-			"version": "0.4.4",
+			"version": "0.5.0",
 			"license": "MIT",
 			"dependencies": {
 				"sortablejs": "^1.15.0"

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,6 +29,7 @@ export const DATA_ATTRIBUTES = {
 	SORTABLE_CONTAINER: 'data-sortable-container',
 	COLUMN_POSITION: 'data-column-position',
 	COLUMN_COLOR: 'data-column-color',
+	SWIMLANE_VALUE: 'data-swimlane-value',
 } as const;
 
 /** CSS class names */
@@ -81,6 +82,17 @@ export const CSS_CLASSES = {
 	COLUMN_COLOR_SWATCH: 'obk-column-color-swatch',
 	COLUMN_COLOR_SWATCH_ACTIVE: 'obk-column-color-swatch--active',
 	COLUMN_COLOR_NONE: 'obk-column-color-none',
+
+	// Swimlane (horizontal rows grouping a second property)
+	BOARD_SWIMLANE: 'obk-board--swimlane',
+	SWIMLANE: 'obk-swimlane',
+	SWIMLANE_HEADER: 'obk-swimlane-header',
+	SWIMLANE_DRAG_HANDLE: 'obk-swimlane-drag-handle',
+	SWIMLANE_TITLE: 'obk-swimlane-title',
+	SWIMLANE_COUNT: 'obk-swimlane-count',
+	SWIMLANE_BOARD: 'obk-swimlane-board',
+	SWIMLANE_DRAGGING: 'obk-swimlane-dragging',
+	SWIMLANE_GHOST: 'obk-swimlane-ghost',
 } as const;
 
 /** Sortable.js configuration constants */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -86,8 +86,10 @@ export const CSS_CLASSES = {
 	// Swimlane (horizontal rows grouping a second property)
 	BOARD_SWIMLANE: 'obk-board--swimlane',
 	SWIMLANE: 'obk-swimlane',
+	SWIMLANE_COLLAPSED: 'obk-swimlane--collapsed',
 	SWIMLANE_HEADER: 'obk-swimlane-header',
 	SWIMLANE_DRAG_HANDLE: 'obk-swimlane-drag-handle',
+	SWIMLANE_TOGGLE: 'obk-swimlane-toggle',
 	SWIMLANE_TITLE: 'obk-swimlane-title',
 	SWIMLANE_COUNT: 'obk-swimlane-count',
 	SWIMLANE_BOARD: 'obk-swimlane-board',

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -118,10 +118,26 @@ export class KanbanView extends BasesView {
 	containerEl: HTMLElement;
 	private legacyData: LegacyData | null;
 	private groupByPropertyId: BasesPropertyId | null = null;
+	private swimlaneByPropertyId: BasesPropertyId | null = null;
 	private cardTitlePropertyId: BasesPropertyId | null = null;
+
+	/**
+	 * Card drag sortables.
+	 * Flat mode key:     "columnValue"
+	 * Swimlane mode key: "swimlaneValue||columnValue"
+	 */
 	private _columnSortables: Map<string, Sortable> = new Map();
-	private _entryMap: Map<string, BasesEntry> = new Map();
+	/**
+	 * Column-reorder sortables — one per swimlane board in swimlane mode,
+	 * keyed by swimlane value.  Unused in flat mode (columnSortable covers that).
+	 */
+	private _columnBoardSortables: Map<string, Sortable> = new Map();
+	/** Swimlane row reorder sortable (swimlane mode only). */
+	private _swimlaneSortable: Sortable | null = null;
+	/** Column reorder sortable for the flat-mode board. */
 	private columnSortable: Sortable | null = null;
+
+	private _entryMap: Map<string, BasesEntry> = new Map();
 	private _debouncedRender: DebouncedFn<() => void>;
 	private activeColorPicker: HTMLElement | null = null;
 
@@ -135,18 +151,25 @@ export class KanbanView extends BasesView {
 	 *
 	 * This breaks the config.set() → onDataUpdated() feedback loop that caused
 	 * state thrashing on every render cycle.
+	 *
+	 * Card order keys in swimlane mode use the composite format "swimlaneValue||columnValue"
+	 * so the same cardOrders map works for both flat and swimlane modes.
 	 */
 	private _lastOrderKey: string = '';
 	private _lastWrapValue: boolean | null = null;
 	private _lastCardTitlePropertyId: BasesPropertyId | null | undefined = undefined;
+	private _lastSwimlanePropertyId: BasesPropertyId | null | undefined = undefined;
 
 	private _prefs: { columnOrder: string[]; cardOrders: Record<string, string[]>; columnColors: Record<string, string> } =
 		{
 			columnOrder: [],
 			cardOrders: {},
-			columnColors: {}, // columnValue → colorName
+			columnColors: {},
 		};
 	private _prefsPropertyId: BasesPropertyId | null = null;
+
+	private _swimlanePrefs: { swimlaneOrder: string[] } = { swimlaneOrder: [] };
+	private _swimlanePrefsPropertyId: BasesPropertyId | null = null;
 
 	/**
 	 * True while a card or column drag is in flight. When set, patchColumnCards
@@ -192,10 +215,11 @@ export class KanbanView extends BasesView {
 	private loadConfig(): void {
 		this.groupByPropertyId = this.config.getAsPropertyId('groupByProperty');
 		this.cardTitlePropertyId = this.config.getAsPropertyId('cardTitleProperty');
+		this.swimlaneByPropertyId = this.config.getAsPropertyId('swimlaneByProperty');
 	}
 
 	/**
-	 * Load display preferences from config for the given propertyId.
+	 * Load display preferences from config for the given column property.
 	 * Called once when groupByPropertyId changes; subsequent renders reuse _prefs.
 	 */
 	private _loadPrefs(propertyId: BasesPropertyId): void {
@@ -230,6 +254,15 @@ export class KanbanView extends BasesView {
 		this._prefs.columnColors = columnColors ? { ...columnColors } : {};
 	}
 
+	/** Load swimlane row order from config for the given swimlane property. */
+	private _loadSwimlanePrefs(propertyId: BasesPropertyId): void {
+		this._swimlanePrefsPropertyId = propertyId;
+		const rawOrders = this.config?.get('swimlaneOrders');
+		const allOrders = isColumnOrders(rawOrders) ? rawOrders : {};
+		const savedOrder = allOrders[propertyId] ?? null;
+		this._swimlanePrefs.swimlaneOrder = savedOrder ? [...savedOrder] : [];
+	}
+
 	/**
 	 * Write _prefs back to config. Called only on user actions (drag-drop,
 	 * column remove, color change) — never during renders.
@@ -250,6 +283,37 @@ export class KanbanView extends BasesView {
 		this._persistConfigKey('columnOrders', isColumnOrders, this._prefs.columnOrder);
 		this._persistConfigKey('cardOrders', isCardOrders, this._prefs.cardOrders);
 		this._persistConfigKey('columnColors', isColumnColors, this._prefs.columnColors);
+	}
+
+	private _persistSwimlanePrefs(): void {
+		if (!this._swimlanePrefsPropertyId) return;
+		const rawOrders = this.config?.get('swimlaneOrders');
+		const allOrders = isColumnOrders(rawOrders) ? rawOrders : {};
+		if (JSON.stringify(allOrders[this._swimlanePrefsPropertyId]) !== JSON.stringify(this._swimlanePrefs.swimlaneOrder)) {
+			this.config?.set('swimlaneOrders', {
+				...allOrders,
+				[this._swimlanePrefsPropertyId]: this._swimlanePrefs.swimlaneOrder,
+			});
+		}
+	}
+
+	/**
+	 * True when swimlane mode is active (a swimlane property is selected and it
+	 * differs from the column group-by property). Use this instead of checking
+	 * swimlaneByPropertyId directly, because the raw field may be non-null even
+	 * when the user picked the same property for both axes.
+	 */
+	private get isSwimlaneModeActive(): boolean {
+		return !!this.swimlaneByPropertyId && this.swimlaneByPropertyId !== this.groupByPropertyId;
+	}
+
+	/**
+	 * Composite key for card order storage.
+	 * Flat mode:     cardOrderKey("Todo")           → "Todo"
+	 * Swimlane mode: cardOrderKey("Todo", "Backlog") → "Backlog||Todo"
+	 */
+	private cardOrderKey(columnValue: string, swimlaneValue?: string): string {
+		return swimlaneValue ? `${swimlaneValue}||${columnValue}` : columnValue;
 	}
 
 	private render(): void {
@@ -273,9 +337,20 @@ export class KanbanView extends BasesView {
 			// value so the board renders from persisted prefs rather than switching
 			// to an unrelated property.
 
-			// Reload prefs when the group-by property changes
+			// Reload prefs when the column property changes
 			if (this.groupByPropertyId !== this._prefsPropertyId) {
 				this._loadPrefs(this.groupByPropertyId);
+			}
+
+			// Swimlane mode is active only when a different property is selected
+			const hasSwimlane = !!this.swimlaneByPropertyId && this.swimlaneByPropertyId !== this.groupByPropertyId;
+
+			// Reload/clear swimlane prefs when the swimlane property changes
+			if (hasSwimlane && this.swimlaneByPropertyId !== this._swimlanePrefsPropertyId) {
+				this._loadSwimlanePrefs(this.swimlaneByPropertyId);
+			} else if (!hasSwimlane && this._swimlanePrefsPropertyId !== null) {
+				this._swimlanePrefsPropertyId = null;
+				this._swimlanePrefs = { swimlaneOrder: [] };
 			}
 
 			const hasNoEntries = entries.length === 0;
@@ -293,31 +368,7 @@ export class KanbanView extends BasesView {
 			// Build path→entry lookup map for O(1) access in handleCardDrop
 			this._entryMap = new Map(entries.map((e: BasesEntry) => [e.file.path, e]));
 
-			// Group entries by group by property value
-			const groupedEntries = this.groupEntriesByProperty(entries, this.groupByPropertyId);
-
-			// Apply saved card order within each column
-			groupedEntries.forEach((columnEntries, value) => {
-				const savedOrder = this._prefs.cardOrders[value];
-				if (savedOrder) {
-					groupedEntries.set(value, this.applyCardOrder(columnEntries, savedOrder));
-				}
-			});
-
-			// Merge any newly-seen column values into prefs and persist eagerly.
-			// This is the only place render() calls _persistPrefs(), and only when
-			// new columns appear — not on every render pass.
-			const liveValues = Array.from(groupedEntries.keys());
-			const newValues = liveValues.filter((v) => !this._prefs.columnOrder.includes(v));
-			if (newValues.length > 0) {
-				const isInitialOrder = this._prefs.columnOrder.length === 0;
-				// No prior order — sort alphabetically as the initial ordering
-				this._prefs.columnOrder = isInitialOrder ? [...newValues].sort() : [...this._prefs.columnOrder, ...newValues];
-				this._persistPrefs();
-			}
-
-			const orderedValues = this.getOrderedColumnValues(liveValues);
-
+			// Change detection flags
 			const currentOrderKey = JSON.stringify(this.config?.getOrder() ?? []);
 			const orderChanged = currentOrderKey !== this._lastOrderKey;
 			this._lastOrderKey = currentOrderKey;
@@ -330,21 +381,96 @@ export class KanbanView extends BasesView {
 			const cardTitleChanged = currentCardTitlePropertyId !== this._lastCardTitlePropertyId;
 			this._lastCardTitlePropertyId = currentCardTitlePropertyId;
 
+			const effectiveSwimlaneId = hasSwimlane ? this.swimlaneByPropertyId : null;
+			const swimlaneChanged = effectiveSwimlaneId !== this._lastSwimlanePropertyId;
+			this._lastSwimlanePropertyId = effectiveSwimlaneId;
+
 			const existingBoard = this.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.BOARD}`);
-			if (
+			const baseNeedsRebuild =
 				!existingBoard ||
 				this._prefsPropertyId !== this.groupByPropertyId ||
 				orderChanged ||
 				wrapChanged ||
-				cardTitleChanged
-			) {
-				this.fullRebuild(orderedValues, groupedEntries);
+				cardTitleChanged ||
+				swimlaneChanged;
+
+			if (hasSwimlane) {
+				this._renderSwimlane(entries, existingBoard, baseNeedsRebuild);
 			} else {
-				this.patchBoard(existingBoard, orderedValues, groupedEntries);
+				this._renderFlat(entries, existingBoard, baseNeedsRebuild);
 			}
+
 			this.reapplyActiveCard();
 		} catch (error) {
 			console.error('KanbanView error:', error);
+		}
+	}
+
+	private _renderFlat(entries: BasesEntry[], existingBoard: HTMLElement | null, baseNeedsRebuild: boolean): void {
+		const groupedEntries = this.groupEntriesByProperty(entries, this.groupByPropertyId);
+
+		// Apply saved card order within each column
+		groupedEntries.forEach((columnEntries, value) => {
+			const savedOrder = this._prefs.cardOrders[value];
+			if (savedOrder) {
+				groupedEntries.set(value, this.applyCardOrder(columnEntries, savedOrder));
+			}
+		});
+
+		// Merge any newly-seen column values into prefs and persist eagerly
+		const liveValues = Array.from(groupedEntries.keys());
+		const newValues = liveValues.filter((v) => !this._prefs.columnOrder.includes(v));
+		if (newValues.length > 0) {
+			const isInitialOrder = this._prefs.columnOrder.length === 0;
+			this._prefs.columnOrder = isInitialOrder ? [...newValues].sort() : [...this._prefs.columnOrder, ...newValues];
+			this._persistPrefs();
+		}
+
+		const orderedValues = this.getOrderedColumnValues(liveValues);
+
+		if (baseNeedsRebuild) {
+			this.fullRebuild(orderedValues, groupedEntries);
+		} else {
+			this.patchBoard(existingBoard, orderedValues, groupedEntries);
+		}
+	}
+
+	private _renderSwimlane(entries: BasesEntry[], existingBoard: HTMLElement | null, baseNeedsRebuild: boolean): void {
+		const swimlaneGrouped = this.groupEntriesByProperty(entries, this.swimlaneByPropertyId);
+
+		// Compute the union of all column values across every swimlane
+		const allColValSet = new Set<string>();
+		swimlaneGrouped.forEach((slEntries) => {
+			this.groupEntriesByProperty(slEntries, this.groupByPropertyId).forEach((_, k) => allColValSet.add(k));
+		});
+		const allColumnValues = Array.from(allColValSet);
+
+		// Merge new swimlane values into prefs
+		const liveSwimlaneValues = Array.from(swimlaneGrouped.keys());
+		const newSwimlaneValues = liveSwimlaneValues.filter((v) => !this._swimlanePrefs.swimlaneOrder.includes(v));
+		if (newSwimlaneValues.length > 0) {
+			const isInitial = this._swimlanePrefs.swimlaneOrder.length === 0;
+			this._swimlanePrefs.swimlaneOrder = isInitial
+				? [...newSwimlaneValues].sort()
+				: [...this._swimlanePrefs.swimlaneOrder, ...newSwimlaneValues];
+			this._persistSwimlanePrefs();
+		}
+
+		// Merge new column values into prefs
+		const newColValues = allColumnValues.filter((v) => !this._prefs.columnOrder.includes(v));
+		if (newColValues.length > 0) {
+			const isInitialOrder = this._prefs.columnOrder.length === 0;
+			this._prefs.columnOrder = isInitialOrder ? [...newColValues].sort() : [...this._prefs.columnOrder, ...newColValues];
+			this._persistPrefs();
+		}
+
+		const orderedColumns = this.getOrderedColumnValues(allColumnValues);
+		const orderedSwimlanes = this.getOrderedSwimlaneValues(liveSwimlaneValues);
+
+		if (baseNeedsRebuild) {
+			this.fullRebuildSwimlane(orderedColumns, orderedSwimlanes, swimlaneGrouped);
+		} else {
+			this.patchSwimlaneBoard(existingBoard, orderedColumns, orderedSwimlanes, swimlaneGrouped);
 		}
 	}
 
@@ -355,6 +481,12 @@ export class KanbanView extends BasesView {
 			this.columnSortable.destroy();
 			this.columnSortable = null;
 		}
+		this._columnBoardSortables.forEach((s) => s.destroy());
+		this._columnBoardSortables.clear();
+		if (this._swimlaneSortable) {
+			this._swimlaneSortable.destroy();
+			this._swimlaneSortable = null;
+		}
 	}
 
 	private fullReset(): void {
@@ -363,6 +495,7 @@ export class KanbanView extends BasesView {
 		this._entryMap.clear();
 	}
 
+	/** Flat mode full rebuild. */
 	private fullRebuild(orderedValues: string[], groupedEntries: Map<string, BasesEntry[]>): void {
 		this.containerEl.empty();
 		this.destroySortables();
@@ -375,6 +508,173 @@ export class KanbanView extends BasesView {
 
 		this.initializeSortable();
 		this.initializeColumnSortable();
+	}
+
+	/** Swimlane mode full rebuild. */
+	private fullRebuildSwimlane(
+		orderedColumns: string[],
+		orderedSwimlanes: string[],
+		swimlaneGrouped: Map<string, BasesEntry[]>,
+	): void {
+		this.containerEl.empty();
+		this.destroySortables();
+
+		const boardEl = this.containerEl.createDiv({
+			cls: `${CSS_CLASSES.BOARD} ${CSS_CLASSES.BOARD_SWIMLANE}`,
+		});
+
+		orderedSwimlanes.forEach((slValue) => {
+			const slEntries = swimlaneGrouped.get(slValue) ?? [];
+			const colGrouped = this.buildColumnGrouped(slEntries, slValue);
+			const slEl = this.createSwimlane(slValue, orderedColumns, colGrouped);
+			boardEl.appendChild(slEl);
+		});
+
+		this.initializeSortableForSwimlanes();
+		this.initializeColumnSortablesForSwimlanes();
+		this.initializeSwimlaneSort();
+	}
+
+	/**
+	 * Group a set of entries by the column property and apply saved card order.
+	 * swimlaneValue is passed in swimlane mode to build the composite card-order key.
+	 */
+	private buildColumnGrouped(slEntries: BasesEntry[], swimlaneValue?: string): Map<string, BasesEntry[]> {
+		const colGrouped = this.groupEntriesByProperty(slEntries, this.groupByPropertyId);
+		colGrouped.forEach((colEntries, colValue) => {
+			const key = this.cardOrderKey(colValue, swimlaneValue);
+			const savedOrder = this._prefs.cardOrders[key];
+			if (savedOrder) {
+				colGrouped.set(colValue, this.applyCardOrder(colEntries, savedOrder));
+			}
+		});
+		return colGrouped;
+	}
+
+	private createSwimlane(slValue: string, orderedColumns: string[], colGrouped: Map<string, BasesEntry[]>): HTMLElement {
+		const slEl = document.createElement('div');
+		slEl.className = CSS_CLASSES.SWIMLANE;
+		slEl.setAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE, slValue);
+
+		const headerEl = slEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_HEADER });
+		const dragHandle = headerEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_DRAG_HANDLE });
+		dragHandle.textContent = '⋮⋮';
+		headerEl.createSpan({ text: slValue, cls: CSS_CLASSES.SWIMLANE_TITLE });
+		const totalEntries = Array.from(colGrouped.values()).reduce((sum, arr) => sum + arr.length, 0);
+		headerEl.createSpan({ text: `${totalEntries}`, cls: CSS_CLASSES.SWIMLANE_COUNT });
+
+		const innerBoardEl = slEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_BOARD });
+		orderedColumns.forEach((colValue) => {
+			const colEl = this.createColumn(colValue, colGrouped.get(colValue) ?? []);
+			innerBoardEl.appendChild(colEl);
+		});
+
+		return slEl;
+	}
+
+	/** Patch the swimlane board in place (add/remove/reorder swimlane rows and their columns). */
+	private patchSwimlaneBoard(
+		boardEl: HTMLElement,
+		orderedColumns: string[],
+		orderedSwimlanes: string[],
+		swimlaneGrouped: Map<string, BasesEntry[]>,
+	): void {
+		const existingSwimlanes = new Map<string, HTMLElement>();
+		boardEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`).forEach((sl) => {
+			const val = sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE);
+			if (val !== null) existingSwimlanes.set(val, sl);
+		});
+
+		const newSwimlaneSet = new Set(orderedSwimlanes);
+
+		// Remove swimlanes no longer present
+		existingSwimlanes.forEach((slEl, value) => {
+			if (!newSwimlaneSet.has(value)) {
+				this.detachSwimlane(value, slEl);
+				existingSwimlanes.delete(value);
+			}
+		});
+
+		// Add new swimlane rows or patch existing ones
+		orderedSwimlanes.forEach((slValue) => {
+			const slEntries = swimlaneGrouped.get(slValue) ?? [];
+			const colGrouped = this.buildColumnGrouped(slEntries, slValue);
+
+			if (!existingSwimlanes.has(slValue)) {
+				const slEl = this.createSwimlane(slValue, orderedColumns, colGrouped);
+				boardEl.appendChild(slEl);
+				existingSwimlanes.set(slValue, slEl);
+				const innerBoard = slEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_BOARD}`);
+				if (innerBoard) {
+					this.attachCardSortablesForSwimlaneBoard(innerBoard, slValue);
+					this.attachColumnSortableForSwimlane(innerBoard, slValue);
+				}
+			} else {
+				const slEl = existingSwimlanes.get(slValue);
+				this.patchSwimlaneRow(slEl, orderedColumns, colGrouped, slValue);
+			}
+		});
+
+		// Re-order swimlane rows in the DOM to match orderedSwimlanes
+		orderedSwimlanes.forEach((value) => {
+			const slEl = existingSwimlanes.get(value);
+			if (slEl) boardEl.appendChild(slEl);
+		});
+	}
+
+	/** Patch columns and their cards within a single swimlane row. */
+	private patchSwimlaneRow(
+		slEl: HTMLElement,
+		orderedColumns: string[],
+		colGrouped: Map<string, BasesEntry[]>,
+		slValue: string,
+	): void {
+		const innerBoard = slEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_BOARD}`);
+		if (!innerBoard) return;
+
+		// Update swimlane count badge
+		const countEl = slEl.querySelector(`.${CSS_CLASSES.SWIMLANE_COUNT}`);
+		if (countEl) {
+			const total = Array.from(colGrouped.values()).reduce((sum, arr) => sum + arr.length, 0);
+			countEl.textContent = `${total}`;
+		}
+
+		const existingColumns = new Map<string, HTMLElement>();
+		innerBoard.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`).forEach((col) => {
+			const val = col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE);
+			if (val !== null) existingColumns.set(val, col);
+		});
+
+		const newColumnSet = new Set(orderedColumns);
+
+		// Remove columns no longer in the global column order
+		existingColumns.forEach((colEl, colValue) => {
+			if (!newColumnSet.has(colValue)) {
+				this.detachColumn(`${slValue}||${colValue}`, colEl);
+				existingColumns.delete(colValue);
+			}
+		});
+
+		// Add missing columns or patch existing ones
+		orderedColumns.forEach((colValue) => {
+			const newEntries = colGrouped.get(colValue) ?? [];
+			if (!existingColumns.has(colValue)) {
+				const colEl = this.createColumn(colValue, newEntries);
+				innerBoard.appendChild(colEl);
+				existingColumns.set(colValue, colEl);
+				const body = colEl.querySelector<HTMLElement>(`.${CSS_CLASSES.COLUMN_BODY}[${DATA_ATTRIBUTES.SORTABLE_CONTAINER}]`);
+				if (body) this.attachCardSortable(body, colValue, slValue);
+			} else {
+				const colEl = existingColumns.get(colValue);
+				this.patchColumnCards(colEl, newEntries);
+			}
+		});
+
+		// Re-order columns in DOM to match orderedColumns
+		orderedColumns.forEach((colValue) => {
+			const colEl = existingColumns.get(colValue);
+			if (colEl) innerBoard.appendChild(colEl);
+		});
 	}
 
 	private patchBoard(boardEl: HTMLElement, orderedValues: string[], groupedEntries: Map<string, BasesEntry[]>): void {
@@ -427,14 +727,16 @@ export class KanbanView extends BasesView {
 		const countEl = columnEl.querySelector(`.${CSS_CLASSES.COLUMN_COUNT}`);
 		if (countEl) countEl.textContent = `${newEntries.length}`;
 
-		// Sync remove button: show only when column has no entries
-		const headerEl = columnEl.querySelector<HTMLElement>(`.${CSS_CLASSES.COLUMN_HEADER}`);
-		const columnValue = columnEl.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE);
-		const existingRemoveBtn = headerEl?.querySelector(`.${CSS_CLASSES.COLUMN_REMOVE_BTN}`) ?? null;
-		if (headerEl && newEntries.length === 0 && !existingRemoveBtn && columnValue) {
-			headerEl.appendChild(this.createRemoveButton(columnValue, columnEl));
-		} else if (newEntries.length > 0 && existingRemoveBtn) {
-			existingRemoveBtn.remove();
+		// Sync remove button — only in flat mode (in swimlane mode removing a column is global)
+		if (!this.isSwimlaneModeActive) {
+			const headerEl = columnEl.querySelector<HTMLElement>(`.${CSS_CLASSES.COLUMN_HEADER}`);
+			const columnValue = columnEl.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE);
+			const existingRemoveBtn = headerEl?.querySelector(`.${CSS_CLASSES.COLUMN_REMOVE_BTN}`) ?? null;
+			if (headerEl && newEntries.length === 0 && !existingRemoveBtn && columnValue) {
+				headerEl.appendChild(this.createRemoveButton(columnValue, columnEl));
+			} else if (newEntries.length > 0 && existingRemoveBtn) {
+				existingRemoveBtn.remove();
+			}
 		}
 
 		// Remove cards whose entry is no longer in this column
@@ -521,8 +823,8 @@ export class KanbanView extends BasesView {
 		headerEl.createSpan({ text: value, cls: CSS_CLASSES.COLUMN_TITLE });
 		headerEl.createSpan({ text: `${entries.length}`, cls: CSS_CLASSES.COLUMN_COUNT });
 
-		// Remove button — only shown when the column has no entries
-		if (entries.length === 0) {
+		// Remove button — only in flat mode and only when column has no entries
+		if (entries.length === 0 && !this.isSwimlaneModeActive) {
 			headerEl.appendChild(this.createRemoveButton(value, columnEl));
 		}
 
@@ -568,6 +870,7 @@ export class KanbanView extends BasesView {
 
 		for (const propertyId of order) {
 			if (propertyId === this.groupByPropertyId) continue;
+			if (propertyId === this.swimlaneByPropertyId) continue;
 			const value = entry.getValue(propertyId);
 			if (value === null) continue;
 			const valueStr = value.toString().trim();
@@ -683,13 +986,34 @@ export class KanbanView extends BasesView {
 		return btn;
 	}
 
-	private detachColumn(value: string, colEl: HTMLElement): void {
-		const sortable = this._columnSortables.get(value);
+	/**
+	 * Detach a column element: destroy its card Sortable and remove from DOM.
+	 * key is the _columnSortables map key ("colValue" or "slValue||colValue").
+	 */
+	private detachColumn(key: string, colEl: HTMLElement): void {
+		const sortable = this._columnSortables.get(key);
 		if (sortable) {
 			sortable.destroy();
-			this._columnSortables.delete(value);
+			this._columnSortables.delete(key);
 		}
 		colEl.remove();
+	}
+
+	/** Detach a swimlane row: destroy all its card/column sortables and remove from DOM. */
+	private detachSwimlane(slValue: string, slEl: HTMLElement): void {
+		// Destroy all card sortables belonging to this swimlane
+		const prefix = `${slValue}||`;
+		const keysToDelete = Array.from(this._columnSortables.keys()).filter((k) => k.startsWith(prefix));
+		keysToDelete.forEach((k) => {
+			this._columnSortables.get(k)?.destroy();
+			this._columnSortables.delete(k);
+		});
+
+		// Destroy the column-board sortable for this swimlane
+		this._columnBoardSortables.get(slValue)?.destroy();
+		this._columnBoardSortables.delete(slValue);
+
+		slEl.remove();
 	}
 
 	private removeColumn(value: string, columnEl: HTMLElement): void {
@@ -699,7 +1023,8 @@ export class KanbanView extends BasesView {
 		this.detachColumn(value, columnEl);
 	}
 
-	private attachCardSortable(body: HTMLElement, value: string): void {
+	private attachCardSortable(body: HTMLElement, columnValue: string, swimlaneValue?: string): void {
+		const key = swimlaneValue ? `${swimlaneValue}||${columnValue}` : columnValue;
 		const sortable = new Sortable(body, {
 			group: SORTABLE_GROUP,
 			animation: SORTABLE_CONFIG.ANIMATION_DURATION,
@@ -716,9 +1041,10 @@ export class KanbanView extends BasesView {
 				void this.handleCardDrop(evt);
 			},
 		});
-		this._columnSortables.set(value, sortable);
+		this._columnSortables.set(key, sortable);
 	}
 
+	/** Flat mode: attach card sortables to all column bodies in the board. */
 	private initializeSortable(): void {
 		const selector = `.${CSS_CLASSES.COLUMN_BODY}[${DATA_ATTRIBUTES.SORTABLE_CONTAINER}]`;
 		this.containerEl.querySelectorAll(selector).forEach((columnBody) => {
@@ -727,6 +1053,112 @@ export class KanbanView extends BasesView {
 			const value = colEl instanceof HTMLElement ? colEl.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE) : null;
 			if (!value) return;
 			this.attachCardSortable(columnBody, value);
+		});
+	}
+
+	/** Swimlane mode: attach card sortables to all column bodies (uses composite key). */
+	private initializeSortableForSwimlanes(): void {
+		const selector = `.${CSS_CLASSES.COLUMN_BODY}[${DATA_ATTRIBUTES.SORTABLE_CONTAINER}]`;
+		this.containerEl.querySelectorAll(selector).forEach((columnBody) => {
+			if (!(columnBody instanceof HTMLElement)) return;
+			const colEl = columnBody.closest(`.${CSS_CLASSES.COLUMN}`);
+			const columnValue = colEl instanceof HTMLElement ? colEl.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE) : null;
+			if (!columnValue) return;
+			const slEl = columnBody.closest(`.${CSS_CLASSES.SWIMLANE}`);
+			const swimlaneValue =
+				slEl instanceof HTMLElement ? (slEl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) ?? undefined) : undefined;
+			this.attachCardSortable(columnBody, columnValue, swimlaneValue);
+		});
+	}
+
+	/** Attach card sortables for all columns inside a single swimlane board element. */
+	private attachCardSortablesForSwimlaneBoard(slBoard: HTMLElement, slValue: string): void {
+		const selector = `.${CSS_CLASSES.COLUMN_BODY}[${DATA_ATTRIBUTES.SORTABLE_CONTAINER}]`;
+		slBoard.querySelectorAll(selector).forEach((columnBody) => {
+			if (!(columnBody instanceof HTMLElement)) return;
+			const colEl = columnBody.closest(`.${CSS_CLASSES.COLUMN}`);
+			const columnValue = colEl instanceof HTMLElement ? colEl.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE) : null;
+			if (!columnValue) return;
+			this.attachCardSortable(columnBody, columnValue, slValue);
+		});
+	}
+
+	/** Flat mode: column reorder sortable on the board. */
+	private initializeColumnSortable(): void {
+		if (this.columnSortable) {
+			this.columnSortable.destroy();
+		}
+
+		const boardEl = this.containerEl.querySelector(`.${CSS_CLASSES.BOARD}`);
+		if (!boardEl || !(boardEl instanceof HTMLElement)) return;
+
+		this.columnSortable = new Sortable(boardEl, {
+			animation: SORTABLE_CONFIG.ANIMATION_DURATION,
+			handle: `.${CSS_CLASSES.COLUMN_DRAG_HANDLE}`,
+			draggable: `.${CSS_CLASSES.COLUMN}`,
+			ghostClass: CSS_CLASSES.COLUMN_GHOST,
+			dragClass: CSS_CLASSES.COLUMN_DRAGGING,
+			onStart: () => {
+				this._dragging = true;
+			},
+			onEnd: (evt: Sortable.SortableEvent) => {
+				this._dragging = false;
+				this.handleColumnDrop(evt);
+			},
+		});
+	}
+
+	/** Swimlane mode: create one column-reorder sortable per swimlane board. */
+	private initializeColumnSortablesForSwimlanes(): void {
+		this.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_BOARD}`).forEach((slBoard) => {
+			const slEl = slBoard.closest<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+			const slValue = slEl?.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) ?? '';
+			this.attachColumnSortableForSwimlane(slBoard, slValue);
+		});
+	}
+
+	private attachColumnSortableForSwimlane(slBoard: HTMLElement, slValue: string): void {
+		const existing = this._columnBoardSortables.get(slValue);
+		if (existing) existing.destroy();
+
+		const s = new Sortable(slBoard, {
+			animation: SORTABLE_CONFIG.ANIMATION_DURATION,
+			handle: `.${CSS_CLASSES.COLUMN_DRAG_HANDLE}`,
+			draggable: `.${CSS_CLASSES.COLUMN}`,
+			ghostClass: CSS_CLASSES.COLUMN_GHOST,
+			dragClass: CSS_CLASSES.COLUMN_DRAGGING,
+			onStart: () => {
+				this._dragging = true;
+			},
+			onEnd: (evt: Sortable.SortableEvent) => {
+				this._dragging = false;
+				this.handleColumnDropForSwimlane(evt, slBoard);
+			},
+		});
+		this._columnBoardSortables.set(slValue, s);
+	}
+
+	/** Swimlane mode: sortable for reordering swimlane rows on the outer board. */
+	private initializeSwimlaneSort(): void {
+		if (this._swimlaneSortable) {
+			this._swimlaneSortable.destroy();
+		}
+		const boardEl = this.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.BOARD}`);
+		if (!boardEl) return;
+
+		this._swimlaneSortable = new Sortable(boardEl, {
+			animation: SORTABLE_CONFIG.ANIMATION_DURATION,
+			handle: `.${CSS_CLASSES.SWIMLANE_DRAG_HANDLE}`,
+			draggable: `.${CSS_CLASSES.SWIMLANE}`,
+			ghostClass: CSS_CLASSES.SWIMLANE_GHOST,
+			dragClass: CSS_CLASSES.SWIMLANE_DRAGGING,
+			onStart: () => {
+				this._dragging = true;
+			},
+			onEnd: (evt: Sortable.SortableEvent) => {
+				this._dragging = false;
+				this.handleSwimlaneDrop(evt);
+			},
 		});
 	}
 
@@ -767,25 +1199,40 @@ export class KanbanView extends BasesView {
 			return;
 		}
 
+		// Determine swimlane context (null in flat mode)
+		const swimlaneSelector = `.${CSS_CLASSES.SWIMLANE}`;
+		const oldSwimlaneEl = evt.from.closest(swimlaneSelector);
+		const newSwimlaneEl = evt.to.closest(swimlaneSelector);
+		const oldSwimlaneValue =
+			oldSwimlaneEl instanceof HTMLElement ? oldSwimlaneEl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) : null;
+		const newSwimlaneValue =
+			newSwimlaneEl instanceof HTMLElement ? newSwimlaneEl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) : null;
+
 		// Helper: read card paths from a column body element
 		const getColumnPaths = (bodyEl: Element): string[] =>
 			Array.from(bodyEl.querySelectorAll(`.${CSS_CLASSES.CARD}`))
 				.map((c) => (c instanceof HTMLElement ? c.getAttribute(DATA_ATTRIBUTES.ENTRY_PATH) : null))
 				.filter((p): p is string => p !== null);
 
-		// Same-column reorder: update prefs and persist
-		if (oldColumnValue === newColumnValue) {
-			this._prefs.cardOrders[newColumnValue] = getColumnPaths(evt.to);
+		const sameColumn = oldColumnValue === newColumnValue;
+		const sameSwimlane = oldSwimlaneValue === newSwimlaneValue;
+
+		const oldCardOrderKey = this.cardOrderKey(oldColumnValue ?? '', oldSwimlaneValue ?? undefined);
+		const newCardOrderKey = this.cardOrderKey(newColumnValue, newSwimlaneValue ?? undefined);
+
+		// Same position: just update card order and return
+		if (sameColumn && sameSwimlane) {
+			this._prefs.cardOrders[newCardOrderKey] = getColumnPaths(evt.to);
 			this._persistPrefs();
 			return;
 		}
 
-		// Cross-column drop: capture DOM order for both columns
+		// Cross-column or cross-swimlane drop: capture DOM order for both sides
 		if (oldColumnEl instanceof HTMLElement && oldColumnValue) {
 			const oldBody = oldColumnEl.querySelector(`.${CSS_CLASSES.COLUMN_BODY}`);
-			if (oldBody) this._prefs.cardOrders[oldColumnValue] = getColumnPaths(oldBody);
+			if (oldBody) this._prefs.cardOrders[oldCardOrderKey] = getColumnPaths(oldBody);
 		}
-		this._prefs.cardOrders[newColumnValue] = getColumnPaths(evt.to);
+		this._prefs.cardOrders[newCardOrderKey] = getColumnPaths(evt.to);
 		this._persistPrefs();
 
 		const entry = this._entryMap.get(entryPath);
@@ -800,21 +1247,85 @@ export class KanbanView extends BasesView {
 		}
 
 		try {
-			const valueToSet = newColumnValue === UNCATEGORIZED_LABEL ? '' : newColumnValue;
-			const parsedProperty = parsePropertyId(this._prefsPropertyId);
-			const propertyName = parsedProperty.name;
+			const parsedColumnProperty = parsePropertyId(this._prefsPropertyId);
+			const columnValueToSet = newColumnValue === UNCATEGORIZED_LABEL ? '' : newColumnValue;
+
+			let parsedSwimlaneProperty: ReturnType<typeof parsePropertyId> | null = null;
+			let swimlaneValueToSet: string | null = null;
+			if (this.swimlaneByPropertyId && !sameSwimlane && newSwimlaneValue !== null) {
+				parsedSwimlaneProperty = parsePropertyId(this.swimlaneByPropertyId);
+				swimlaneValueToSet = newSwimlaneValue === UNCATEGORIZED_LABEL ? '' : newSwimlaneValue;
+			}
 
 			await this.app.fileManager.processFrontMatter(entry.file, (frontmatter: Record<string, unknown>) => {
-				if (valueToSet === '') {
-					delete frontmatter[propertyName];
-				} else {
-					frontmatter[propertyName] = valueToSet;
+				if (!sameColumn) {
+					if (columnValueToSet === '') {
+						delete frontmatter[parsedColumnProperty.name];
+					} else {
+						frontmatter[parsedColumnProperty.name] = columnValueToSet;
+					}
+				}
+				if (parsedSwimlaneProperty !== null && swimlaneValueToSet !== null) {
+					if (swimlaneValueToSet === '') {
+						delete frontmatter[parsedSwimlaneProperty.name];
+					} else {
+						frontmatter[parsedSwimlaneProperty.name] = swimlaneValueToSet;
+					}
 				}
 			});
 		} catch (error) {
 			console.error('Error updating entry property:', error);
 			this.render();
 		}
+	}
+
+	/** Flat mode: persist column order after a column is dragged. */
+	private handleColumnDrop(evt: Sortable.SortableEvent): void {
+		if (!this._prefsPropertyId) return;
+
+		const columns = this.containerEl.querySelectorAll(`.${CSS_CLASSES.COLUMN}`);
+		const order = Array.from(columns)
+			.map((col) => col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE))
+			.filter((v): v is string => v !== null);
+
+		this._prefs.columnOrder = order;
+		this._persistPrefs();
+	}
+
+	/**
+	 * Swimlane mode: persist column order and sync it to all other swimlane boards.
+	 * Column order is global — dragging in one row reorders all rows.
+	 */
+	private handleColumnDropForSwimlane(evt: Sortable.SortableEvent, draggedSlBoard: HTMLElement): void {
+		if (!this._prefsPropertyId) return;
+
+		const columns = draggedSlBoard.querySelectorAll(`.${CSS_CLASSES.COLUMN}`);
+		const order = Array.from(columns)
+			.map((col) => col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE))
+			.filter((v): v is string => v !== null);
+
+		this._prefs.columnOrder = order;
+		this._persistPrefs();
+
+		// Sync column order to every OTHER swimlane board
+		this.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_BOARD}`).forEach((slBoard) => {
+			if (slBoard === draggedSlBoard) return;
+			order.forEach((colValue) => {
+				const colEl = slBoard.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="${CSS.escape(colValue)}"]`);
+				if (colEl) slBoard.appendChild(colEl);
+			});
+		});
+	}
+
+	/** Swimlane mode: persist swimlane row order after a row is dragged. */
+	private handleSwimlaneDrop(evt: Sortable.SortableEvent): void {
+		const swimlanes = this.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`);
+		const order = Array.from(swimlanes)
+			.map((sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE))
+			.filter((v): v is string => v !== null);
+
+		this._swimlanePrefs.swimlaneOrder = order;
+		this._persistSwimlanePrefs();
 	}
 
 	private findCardEl(path: string): HTMLElement | null {
@@ -847,47 +1358,17 @@ export class KanbanView extends BasesView {
 		return [...this._prefs.columnOrder, ...newValues];
 	}
 
+	private getOrderedSwimlaneValues(liveValues: string[]): string[] {
+		if (!this._swimlanePrefs.swimlaneOrder.length) return liveValues.sort();
+		const newValues = liveValues.filter((v) => !this._swimlanePrefs.swimlaneOrder.includes(v));
+		return [...this._swimlanePrefs.swimlaneOrder, ...newValues];
+	}
+
 	private applyCardOrder(entries: BasesEntry[], savedOrder: string[]): BasesEntry[] {
 		const entryMap = new Map(entries.map((e) => [e.file.path, e]));
 		const ordered = savedOrder.map((p) => entryMap.get(p)).filter((e): e is BasesEntry => e !== undefined);
 		const unsaved = entries.filter((e) => !savedOrder.includes(e.file.path));
 		return [...ordered, ...unsaved];
-	}
-
-	private initializeColumnSortable(): void {
-		if (this.columnSortable) {
-			this.columnSortable.destroy();
-		}
-
-		const boardEl = this.containerEl.querySelector(`.${CSS_CLASSES.BOARD}`);
-		if (!boardEl || !(boardEl instanceof HTMLElement)) return;
-
-		this.columnSortable = new Sortable(boardEl, {
-			animation: SORTABLE_CONFIG.ANIMATION_DURATION,
-			handle: `.${CSS_CLASSES.COLUMN_DRAG_HANDLE}`,
-			draggable: `.${CSS_CLASSES.COLUMN}`,
-			ghostClass: CSS_CLASSES.COLUMN_GHOST,
-			dragClass: CSS_CLASSES.COLUMN_DRAGGING,
-			onStart: () => {
-				this._dragging = true;
-			},
-			onEnd: (evt: Sortable.SortableEvent) => {
-				this._dragging = false;
-				this.handleColumnDrop(evt);
-			},
-		});
-	}
-
-	private handleColumnDrop(evt: Sortable.SortableEvent): void {
-		if (!this._prefsPropertyId) return;
-
-		const columns = this.containerEl.querySelectorAll(`.${CSS_CLASSES.COLUMN}`);
-		const order = Array.from(columns)
-			.map((col) => col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE))
-			.filter((v): v is string => v !== null);
-
-		this._prefs.columnOrder = order;
-		this._persistPrefs();
 	}
 
 	onClose(): void {
@@ -928,6 +1409,13 @@ export class KanbanView extends BasesView {
 				key: 'groupByProperty',
 				filter: (prop: string) => !prop.startsWith('file.'),
 				placeholder: 'Select property',
+			},
+			{
+				displayName: 'Swimlane by',
+				type: 'property',
+				key: 'swimlaneByProperty',
+				filter: (prop: string) => !prop.startsWith('file.'),
+				placeholder: 'None (flat board)',
 			},
 			{
 				displayName: 'Card title property',

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -168,7 +168,10 @@ export class KanbanView extends BasesView {
 		};
 	private _prefsPropertyId: BasesPropertyId | null = null;
 
-	private _swimlanePrefs: { swimlaneOrder: string[] } = { swimlaneOrder: [] };
+	private _swimlanePrefs: { swimlaneOrder: string[]; collapsedSwimlanes: string[] } = {
+		swimlaneOrder: [],
+		collapsedSwimlanes: [],
+	};
 	private _swimlanePrefsPropertyId: BasesPropertyId | null = null;
 
 	/**
@@ -254,13 +257,17 @@ export class KanbanView extends BasesView {
 		this._prefs.columnColors = columnColors ? { ...columnColors } : {};
 	}
 
-	/** Load swimlane row order from config for the given swimlane property. */
+	/** Load swimlane row order and collapsed state from config for the given swimlane property. */
 	private _loadSwimlanePrefs(propertyId: BasesPropertyId): void {
 		this._swimlanePrefsPropertyId = propertyId;
 		const rawOrders = this.config?.get('swimlaneOrders');
 		const allOrders = isColumnOrders(rawOrders) ? rawOrders : {};
 		const savedOrder = allOrders[propertyId] ?? null;
 		this._swimlanePrefs.swimlaneOrder = savedOrder ? [...savedOrder] : [];
+
+		const rawCollapsed = this.config?.get('swimlaneCollapsed');
+		const allCollapsed = isColumnOrders(rawCollapsed) ? rawCollapsed : {};
+		this._swimlanePrefs.collapsedSwimlanes = allCollapsed[propertyId] ? [...allCollapsed[propertyId]] : [];
 	}
 
 	/**
@@ -293,6 +300,18 @@ export class KanbanView extends BasesView {
 			this.config?.set('swimlaneOrders', {
 				...allOrders,
 				[this._swimlanePrefsPropertyId]: this._swimlanePrefs.swimlaneOrder,
+			});
+		}
+
+		const rawCollapsed = this.config?.get('swimlaneCollapsed');
+		const allCollapsed = isColumnOrders(rawCollapsed) ? rawCollapsed : {};
+		if (
+			JSON.stringify(allCollapsed[this._swimlanePrefsPropertyId]) !==
+			JSON.stringify(this._swimlanePrefs.collapsedSwimlanes)
+		) {
+			this.config?.set('swimlaneCollapsed', {
+				...allCollapsed,
+				[this._swimlanePrefsPropertyId]: this._swimlanePrefs.collapsedSwimlanes,
 			});
 		}
 	}
@@ -350,7 +369,7 @@ export class KanbanView extends BasesView {
 				this._loadSwimlanePrefs(this.swimlaneByPropertyId);
 			} else if (!hasSwimlane && this._swimlanePrefsPropertyId !== null) {
 				this._swimlanePrefsPropertyId = null;
-				this._swimlanePrefs = { swimlaneOrder: [] };
+				this._swimlanePrefs = { swimlaneOrder: [], collapsedSwimlanes: [] };
 			}
 
 			const hasNoEntries = entries.length === 0;
@@ -556,12 +575,22 @@ export class KanbanView extends BasesView {
 		slEl.className = CSS_CLASSES.SWIMLANE;
 		slEl.setAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE, slValue);
 
+		const isCollapsed = this._swimlanePrefs.collapsedSwimlanes.includes(slValue);
+		if (isCollapsed) slEl.classList.add(CSS_CLASSES.SWIMLANE_COLLAPSED);
+
 		const headerEl = slEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_HEADER });
 		const dragHandle = headerEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_DRAG_HANDLE });
 		dragHandle.textContent = '⋮⋮';
 		headerEl.createSpan({ text: slValue, cls: CSS_CLASSES.SWIMLANE_TITLE });
 		const totalEntries = Array.from(colGrouped.values()).reduce((sum, arr) => sum + arr.length, 0);
 		headerEl.createSpan({ text: `${totalEntries}`, cls: CSS_CLASSES.SWIMLANE_COUNT });
+
+		const toggleBtn = headerEl.createEl('button', {
+			cls: CSS_CLASSES.SWIMLANE_TOGGLE,
+			attr: { 'aria-label': isCollapsed ? 'Expand swimlane' : 'Collapse swimlane' },
+		});
+		toggleBtn.textContent = isCollapsed ? '▸' : '▾';
+		toggleBtn.addEventListener('click', () => this._toggleSwimlaneCollapsed(slEl, slValue, toggleBtn));
 
 		const innerBoardEl = slEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_BOARD });
 		orderedColumns.forEach((colValue) => {
@@ -570,6 +599,21 @@ export class KanbanView extends BasesView {
 		});
 
 		return slEl;
+	}
+
+	private _toggleSwimlaneCollapsed(slEl: HTMLElement, slValue: string, toggleBtn: HTMLElement): void {
+		const nowCollapsed = slEl.classList.toggle(CSS_CLASSES.SWIMLANE_COLLAPSED);
+		toggleBtn.textContent = nowCollapsed ? '▸' : '▾';
+		toggleBtn.setAttribute('aria-label', nowCollapsed ? 'Expand swimlane' : 'Collapse swimlane');
+
+		if (nowCollapsed) {
+			if (!this._swimlanePrefs.collapsedSwimlanes.includes(slValue)) {
+				this._swimlanePrefs.collapsedSwimlanes = [...this._swimlanePrefs.collapsedSwimlanes, slValue];
+			}
+		} else {
+			this._swimlanePrefs.collapsedSwimlanes = this._swimlanePrefs.collapsedSwimlanes.filter((v) => v !== slValue);
+		}
+		this._persistSwimlanePrefs();
 	}
 
 	/** Patch the swimlane board in place (add/remove/reorder swimlane rows and their columns). */
@@ -919,6 +963,14 @@ export class KanbanView extends BasesView {
 		columnEl.setAttribute(DATA_ATTRIBUTES.COLUMN_COLOR, colorName);
 	}
 
+	/** Apply a color to every column element sharing the same column value (all swimlane rows). */
+	private applyColumnColorToAll(columnValue: string, colorName: string | null): void {
+		const escaped = CSS.escape(columnValue);
+		this.containerEl
+			.querySelectorAll<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="${escaped}"]`)
+			.forEach((el) => this.applyColumnColor(el, colorName));
+	}
+
 	private openColorPicker(anchorEl: HTMLElement, columnEl: HTMLElement, columnValue: string): void {
 		this.activeColorPicker?.remove();
 		this.activeColorPicker = null;
@@ -933,7 +985,7 @@ export class KanbanView extends BasesView {
 		if (!currentColor) noneSwatch.classList.add(CSS_CLASSES.COLUMN_COLOR_SWATCH_ACTIVE);
 		noneSwatch.title = 'No color';
 		noneSwatch.addEventListener('click', () => {
-			this.applyColumnColor(columnEl, null);
+			this.applyColumnColorToAll(columnValue, null);
 			delete this._prefs.columnColors[columnValue];
 			this._persistPrefs();
 			popover.remove();
@@ -948,7 +1000,7 @@ export class KanbanView extends BasesView {
 			swatch.title = color.name;
 			if (currentColor === color.name) swatch.classList.add(CSS_CLASSES.COLUMN_COLOR_SWATCH_ACTIVE);
 			swatch.addEventListener('click', () => {
-				this.applyColumnColor(columnEl, color.name);
+				this.applyColumnColorToAll(columnValue, color.name);
 				this._prefs.columnColors[columnValue] = color.name;
 				this._persistPrefs();
 				popover.remove();

--- a/styles.css
+++ b/styles.css
@@ -490,6 +490,38 @@
 	max-height: none;
 }
 
+/* Collapse toggle button */
+.obk-swimlane-toggle {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	border: none;
+	background: none;
+	cursor: pointer;
+	color: var(--text-muted);
+	font-size: 16px;
+	border-radius: 4px;
+	flex-shrink: 0;
+}
+
+.obk-swimlane-toggle:hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
+}
+
+/* Collapsed swimlane: hide the board and square off the header corners */
+.obk-swimlane--collapsed .obk-swimlane-board {
+	display: none;
+}
+
+.obk-swimlane--collapsed .obk-swimlane-header {
+	border-bottom: none;
+	border-radius: 8px;
+}
+
 /* Swimlane drag-and-drop states */
 .obk-swimlane-dragging {
 	opacity: 0.5;

--- a/styles.css
+++ b/styles.css
@@ -366,3 +366,137 @@
 		flex: 0 0 240px;
 	}
 }
+
+/* ── Swimlane mode ─────────────────────────────────────────────────────────── */
+
+/* Board modifier: vertical stack of swimlane rows instead of horizontal columns */
+.obk-board--swimlane {
+	flex-direction: column;
+	overflow-x: hidden;
+	overflow-y: auto;
+	gap: 12px;
+}
+
+.obk-board--swimlane::-webkit-scrollbar {
+	width: 8px;
+}
+
+.obk-board--swimlane::-webkit-scrollbar-track {
+	background: var(--background-secondary);
+	border-radius: 4px;
+}
+
+.obk-board--swimlane::-webkit-scrollbar-thumb {
+	background: var(--background-modifier-border);
+	border-radius: 4px;
+}
+
+.obk-board--swimlane::-webkit-scrollbar-thumb:hover {
+	background: var(--background-modifier-border-hover);
+}
+
+/* Swimlane row container */
+.obk-swimlane {
+	display: flex;
+	flex-direction: column;
+	background: var(--background-secondary);
+	border-radius: 8px;
+	border: 1px solid var(--background-modifier-border);
+	flex-shrink: 0;
+}
+
+/* Swimlane header */
+.obk-swimlane-header {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 10px 14px;
+	background: var(--background-primary-alt);
+	border-bottom: 1px solid var(--background-modifier-border);
+	border-radius: 8px 8px 0 0;
+	position: sticky;
+	top: 0;
+	z-index: 1;
+}
+
+.obk-swimlane-drag-handle {
+	cursor: grab;
+	padding: 4px;
+	opacity: 0.5;
+	user-select: none;
+	font-size: 16px;
+	line-height: 1;
+	color: var(--text-muted);
+	display: flex;
+	align-items: center;
+	flex-shrink: 0;
+}
+
+.obk-swimlane-drag-handle:hover {
+	opacity: 1;
+	color: var(--text-normal);
+}
+
+.obk-swimlane-drag-handle:active {
+	cursor: grabbing;
+}
+
+.obk-swimlane-title {
+	flex: 1;
+	font-weight: 600;
+	font-size: 14px;
+	color: var(--text-normal);
+}
+
+.obk-swimlane-count {
+	font-size: 12px;
+	color: var(--text-muted);
+	background: var(--background-modifier-border);
+	padding: 2px 8px;
+	border-radius: 12px;
+	flex-shrink: 0;
+}
+
+/* Inner horizontal board of columns within a swimlane */
+.obk-swimlane-board {
+	display: flex;
+	flex-direction: row;
+	gap: 12px;
+	padding: 12px;
+	overflow-x: auto;
+	overflow-y: hidden;
+}
+
+.obk-swimlane-board::-webkit-scrollbar {
+	height: 6px;
+}
+
+.obk-swimlane-board::-webkit-scrollbar-track {
+	background: transparent;
+}
+
+.obk-swimlane-board::-webkit-scrollbar-thumb {
+	background: var(--background-modifier-border);
+	border-radius: 3px;
+}
+
+.obk-swimlane-board::-webkit-scrollbar-thumb:hover {
+	background: var(--background-modifier-border-hover);
+}
+
+/* Columns inside swimlanes are shorter since height is not constrained to the viewport */
+.obk-swimlane-board .obk-column {
+	min-height: 80px;
+	max-height: none;
+}
+
+/* Swimlane drag-and-drop states */
+.obk-swimlane-dragging {
+	opacity: 0.5;
+}
+
+.obk-swimlane-ghost {
+	opacity: 0.3;
+	background: var(--background-modifier-border);
+	border-radius: 8px;
+}

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -137,14 +137,17 @@ describe('View Options', () => {
 	test('getViewOptions returns correct structure', () => {
 		const options = KanbanView.getViewOptions();
 
-		assert.strictEqual(options.length, 3, 'Should return three options');
+		assert.strictEqual(options.length, 4, 'Should return four options');
 		assert.strictEqual(options[0].displayName, 'Group by', 'First option should be Group by');
-		assert.strictEqual(options[1].displayName, 'Card title property', 'Second option should be Card title property');
-		assert.strictEqual(options[1].type, 'property', 'Card title property should be a property selector');
-		assert.strictEqual(options[1].key, 'cardTitleProperty', 'Key should be "cardTitleProperty"');
-		assert.strictEqual(options[2].displayName, 'Wrap property values', 'Third option should be Wrap property values');
-		assert.strictEqual(options[2].type, 'toggle', 'Wrap property values should be a toggle');
-		assert.strictEqual(options[2].key, 'wrapPropertyValues', 'Key should be "wrapPropertyValues"');
+		assert.strictEqual(options[1].displayName, 'Swimlane by', 'Second option should be Swimlane by');
+		assert.strictEqual(options[1].type, 'property', 'Swimlane by should be a property selector');
+		assert.strictEqual(options[1].key, 'swimlaneByProperty', 'Key should be "swimlaneByProperty"');
+		assert.strictEqual(options[2].displayName, 'Card title property', 'Third option should be Card title property');
+		assert.strictEqual(options[2].type, 'property', 'Card title property should be a property selector');
+		assert.strictEqual(options[2].key, 'cardTitleProperty', 'Key should be "cardTitleProperty"');
+		assert.strictEqual(options[3].displayName, 'Wrap property values', 'Fourth option should be Wrap property values');
+		assert.strictEqual(options[3].type, 'toggle', 'Wrap property values should be a toggle');
+		assert.strictEqual(options[3].key, 'wrapPropertyValues', 'Key should be "wrapPropertyValues"');
 	});
 
 	test('Property filter excludes file.* properties', () => {

--- a/tests/swimlane.test.ts
+++ b/tests/swimlane.test.ts
@@ -708,6 +708,205 @@ describe('Swimlane Drag and Drop - Card Drop', () => {
 	});
 });
 
+// ── Column Colors Across Swimlanes ───────────────────────────────────────────
+
+describe('Swimlane Column Colors - Shared Across Rows', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+		// Clean up any leftover popover from a previous test
+		document.querySelectorAll('.obk-column-color-popover').forEach((el) => el.remove());
+	});
+
+	test('Stored column color is applied to all swimlane rows on initial render', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		// Pre-load a color for "To Do" in config
+		controller.config.set('columnColors', { [PROPERTY_STATUS]: { 'To Do': 'red' } });
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const todoColumns = Array.from(
+			view.containerEl.querySelectorAll<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"]`),
+		);
+		assert.ok(todoColumns.length >= 2, 'There should be a "To Do" column in each swimlane');
+
+		for (const col of todoColumns) {
+			assert.strictEqual(
+				col.style.getPropertyValue('--obk-column-accent-color'),
+				'var(--color-red)',
+				'Every "To Do" column across swimlanes should have the red accent',
+			);
+			assert.strictEqual(col.getAttribute('data-column-color'), 'red', 'data-column-color attribute should be set');
+		}
+	});
+
+	test('Columns without a stored color have no accent in any swimlane row', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const allColumns = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`));
+		for (const col of allColumns) {
+			assert.strictEqual(
+				col.style.getPropertyValue('--obk-column-accent-color'),
+				'',
+				'Column without stored color should have no accent variable',
+			);
+			assert.strictEqual(col.getAttribute('data-column-color'), null, 'data-column-color should be absent');
+		}
+	});
+
+	test('Picking a color via the picker immediately applies it to all swimlane rows', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		// Open the color picker on the "To Do" column in the first swimlane
+		const firstSwimlane = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)!;
+		const todoColInFirst = firstSwimlane.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"]`)!;
+		const colorBtn = todoColInFirst.querySelector<HTMLElement>(`.${CSS_CLASSES.COLUMN_COLOR_BTN}`)!;
+		assert.ok(colorBtn, 'Color button should exist on the column header');
+
+		colorBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		const popover = document.querySelector<HTMLElement>('.obk-column-color-popover');
+		assert.ok(popover, 'Color picker popover should appear');
+
+		// Click the first real color swatch (index 0 is "none", index 1 is the first palette color)
+		const swatches = popover!.querySelectorAll<HTMLElement>('.obk-column-color-swatch');
+		assert.ok(swatches.length > 1, 'Popover should have at least one color swatch');
+		const firstColorSwatch = swatches[1];
+		const pickedColor = firstColorSwatch.title;
+		firstColorSwatch.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		// Every "To Do" column across all swimlanes should now have the picked color
+		const todoColumns = Array.from(
+			view.containerEl.querySelectorAll<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"]`),
+		);
+		assert.ok(todoColumns.length >= 2, 'Should have "To Do" in multiple swimlanes');
+
+		for (const col of todoColumns) {
+			assert.strictEqual(
+				col.style.getPropertyValue('--obk-column-accent-color'),
+				`var(--color-${pickedColor})`,
+				`All "To Do" columns should have the ${pickedColor} accent applied immediately`,
+			);
+		}
+	});
+
+	test('Picking a color for one column does not affect sibling columns in other swimlanes', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const firstSwimlane = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)!;
+		const todoColInFirst = firstSwimlane.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"]`)!;
+		const colorBtn = todoColInFirst.querySelector<HTMLElement>(`.${CSS_CLASSES.COLUMN_COLOR_BTN}`)!;
+		colorBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		const popover = document.querySelector<HTMLElement>('.obk-column-color-popover')!;
+		const swatches = popover.querySelectorAll<HTMLElement>('.obk-column-color-swatch');
+		swatches[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		// "Done" columns should be unaffected across all swimlanes
+		const doneColumns = Array.from(
+			view.containerEl.querySelectorAll<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="Done"]`),
+		);
+		assert.ok(doneColumns.length >= 1, 'There should be "Done" columns');
+		for (const col of doneColumns) {
+			assert.strictEqual(
+				col.style.getPropertyValue('--obk-column-accent-color'),
+				'',
+				'"Done" columns should remain uncolored when "To Do" color is set',
+			);
+		}
+	});
+
+	test('Selecting "no color" clears the accent from all swimlane rows', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		controller.config.set('columnColors', { [PROPERTY_STATUS]: { 'To Do': 'green' } });
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		// Verify the color is applied initially
+		const todoColumns = Array.from(
+			view.containerEl.querySelectorAll<HTMLElement>(`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"]`),
+		);
+		assert.ok(
+			todoColumns.every((col) => col.style.getPropertyValue('--obk-column-accent-color') !== ''),
+			'All "To Do" columns should have a color before clearing',
+		);
+
+		// Open the picker and click "no color" (swatch index 0)
+		const firstSwimlane = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)!;
+		const colorBtn = firstSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_COLOR_BTN}`,
+		)!;
+		colorBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		const popover = document.querySelector<HTMLElement>('.obk-column-color-popover')!;
+		const noneSwatch = popover.querySelectorAll<HTMLElement>('.obk-column-color-swatch')[0];
+		noneSwatch.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		for (const col of todoColumns) {
+			assert.strictEqual(
+				col.style.getPropertyValue('--obk-column-accent-color'),
+				'',
+				'All "To Do" columns should have accent cleared after selecting "no color"',
+			);
+			assert.strictEqual(col.getAttribute('data-column-color'), null, 'data-column-color attribute should be removed');
+		}
+	});
+
+	test('Color choice is persisted to config and keyed by column value (not swimlane)', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const firstSwimlane = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)!;
+		const colorBtn = firstSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_COLOR_BTN}`,
+		)!;
+		colorBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		const popover = document.querySelector<HTMLElement>('.obk-column-color-popover')!;
+		const swatches = popover.querySelectorAll<HTMLElement>('.obk-column-color-swatch');
+		const pickedColor = swatches[1].title;
+		swatches[1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+		const savedColors = controller.config.get('columnColors') as Record<string, Record<string, string>> | null;
+		assert.ok(savedColors, 'columnColors should be saved to config');
+		assert.strictEqual(
+			savedColors[PROPERTY_STATUS]?.['To Do'],
+			pickedColor,
+			'Color should be stored under the column value key, not a swimlane-composite key',
+		);
+	});
+});
+
 // ── Preference Persistence ────────────────────────────────────────────────────
 
 describe('Swimlane Preferences - Loading and Persistence', () => {
@@ -794,5 +993,178 @@ describe('Swimlane Preferences - Loading and Persistence', () => {
 			null,
 			'_swimlanePrefsPropertyId should be null after disabling swimlane',
 		);
+	});
+});
+
+// ── Collapse Toggle ──────────────────────────────────────────────────────────
+
+describe('Swimlane Collapse Toggle', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		mockSortable();
+		(global as any).Sortable = mockSortable().Sortable;
+		addClosestPolyfill(document.createElement('div'));
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+	});
+
+	test('Each swimlane header has a toggle button', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+		swimlanes.forEach((slEl) => {
+			const toggleBtn = slEl.querySelector(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+			assert.ok(toggleBtn, 'Swimlane header should have a toggle button');
+		});
+	});
+
+	test('Toggle button shows ▾ (expanded) by default', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+		swimlanes.forEach((slEl) => {
+			const toggleBtn = slEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+			assert.strictEqual(toggleBtn?.textContent, '▾', 'Toggle button should show ▾ when expanded');
+		});
+	});
+
+	test('Clicking toggle collapses the swimlane', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const firstSwimlane = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+		assert.ok(firstSwimlane, 'Swimlane should exist');
+
+		const toggleBtn = firstSwimlane!.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+		assert.ok(toggleBtn, 'Toggle button should exist');
+
+		toggleBtn!.click();
+
+		assert.ok(
+			firstSwimlane!.classList.contains(CSS_CLASSES.SWIMLANE_COLLAPSED),
+			'Swimlane should have collapsed class after toggle',
+		);
+		assert.strictEqual(toggleBtn!.textContent, '▸', 'Toggle button should show ▸ when collapsed');
+	});
+
+	test('Clicking toggle again expands the swimlane', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const firstSwimlane = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+		const toggleBtn = firstSwimlane!.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+
+		toggleBtn!.click();
+		toggleBtn!.click();
+
+		assert.ok(
+			!firstSwimlane!.classList.contains(CSS_CLASSES.SWIMLANE_COLLAPSED),
+			'Swimlane should not have collapsed class after toggling twice',
+		);
+		assert.strictEqual(toggleBtn!.textContent, '▾', 'Toggle button should show ▾ when re-expanded');
+	});
+
+	test('Collapsing a swimlane updates _swimlanePrefs.collapsedSwimlanes', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)).find(
+			(sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) === 'High',
+		);
+		assert.ok(highSwimlane, 'High swimlane should exist');
+
+		const toggleBtn = highSwimlane!.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+		toggleBtn!.click();
+
+		const collapsed = (view as any)._swimlanePrefs.collapsedSwimlanes as string[];
+		assert.ok(collapsed.includes('High'), 'collapsedSwimlanes should include High');
+	});
+
+	test('Expanding a swimlane removes it from _swimlanePrefs.collapsedSwimlanes', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)).find(
+			(sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) === 'High',
+		);
+		const toggleBtn = highSwimlane!.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+
+		toggleBtn!.click();
+		toggleBtn!.click();
+
+		const collapsed = (view as any)._swimlanePrefs.collapsedSwimlanes as string[];
+		assert.ok(!collapsed.includes('High'), 'collapsedSwimlanes should not include High after re-expanding');
+	});
+
+	test('Collapsed state is persisted to config', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)).find(
+			(sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) === 'High',
+		);
+		const toggleBtn = highSwimlane!.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+		toggleBtn!.click();
+
+		const savedCollapsed = controller.config.get('swimlaneCollapsed');
+		assert.ok(savedCollapsed, 'swimlaneCollapsed should be saved to config');
+		const collapsedForProp = (savedCollapsed as any)[PROPERTY_PRIORITY] as string[];
+		assert.ok(Array.isArray(collapsedForProp), 'Should have an array for the swimlane property');
+		assert.ok(collapsedForProp.includes('High'), 'Persisted collapsed state should include High');
+	});
+
+	test('Collapsed state is restored from config on initial render', () => {
+		// Pre-populate config with a collapsed swimlane
+		controller.config.set('swimlaneCollapsed', { [PROPERTY_PRIORITY]: ['High'] });
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)).find(
+			(sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) === 'High',
+		);
+		assert.ok(highSwimlane, 'High swimlane should exist');
+		assert.ok(
+			highSwimlane!.classList.contains(CSS_CLASSES.SWIMLANE_COLLAPSED),
+			'High swimlane should be collapsed based on saved config',
+		);
+
+		const toggleBtn = highSwimlane!.querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+		assert.strictEqual(toggleBtn?.textContent, '▸', 'Toggle button should show ▸ for collapsed swimlane');
+
+		const lowSwimlane = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)).find(
+			(sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) === 'Low',
+		);
+		assert.ok(!lowSwimlane!.classList.contains(CSS_CLASSES.SWIMLANE_COLLAPSED), 'Low swimlane should remain expanded');
+	});
+
+	test('Only the clicked swimlane collapses; others remain expanded', () => {
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`));
+		assert.strictEqual(swimlanes.length, 2, 'Should have 2 swimlanes');
+
+		const firstToggle = swimlanes[0].querySelector<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_TOGGLE}`);
+		firstToggle!.click();
+
+		assert.ok(swimlanes[0].classList.contains(CSS_CLASSES.SWIMLANE_COLLAPSED), 'First swimlane should be collapsed');
+		assert.ok(!swimlanes[1].classList.contains(CSS_CLASSES.SWIMLANE_COLLAPSED), 'Second swimlane should remain expanded');
 	});
 });

--- a/tests/swimlane.test.ts
+++ b/tests/swimlane.test.ts
@@ -1,0 +1,798 @@
+import assert from 'node:assert';
+import { beforeEach, describe, test } from 'node:test';
+import type { BasesEntry } from 'obsidian';
+import { KanbanView } from '../src/kanbanView.ts';
+import { CSS_CLASSES, DATA_ATTRIBUTES, UNCATEGORIZED_LABEL } from '../src/constants.ts';
+import {
+	addClosestPolyfill,
+	createDivWithMethods,
+	createMockApp,
+	createMockBasesEntry,
+	createMockTFile,
+	createMockQueryController,
+	mockSortable,
+	setupKanbanViewWithApp,
+	setupTestEnvironment,
+	triggerDataUpdate,
+} from './helpers.ts';
+import { PROPERTY_PRIORITY, PROPERTY_STATUS, TEST_PROPERTIES } from './fixtures.ts';
+
+setupTestEnvironment();
+
+// CSS.escape is used when syncing column order across swimlane boards.
+// Provide a no-op polyfill if jsdom hasn't exposed it as a global.
+if (typeof (global as any).CSS === 'undefined') {
+	(global as any).CSS = { escape: (s: string) => s };
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/**
+ * 5 entries across 2 swimlane values (priority) × 2 column values (status):
+ *   High / To Do  → Task 1, Task 5
+ *   High / Done   → Task 2
+ *   Low  / To Do  → Task 3
+ *   Low  / Done   → Task 4
+ */
+function createSwimlaneEntries(): BasesEntry[] {
+	return [
+		createMockBasesEntry(createMockTFile('Task 1.md'), {
+			[PROPERTY_STATUS]: 'To Do',
+			[PROPERTY_PRIORITY]: 'High',
+		}),
+		createMockBasesEntry(createMockTFile('Task 2.md'), {
+			[PROPERTY_STATUS]: 'Done',
+			[PROPERTY_PRIORITY]: 'High',
+		}),
+		createMockBasesEntry(createMockTFile('Task 3.md'), {
+			[PROPERTY_STATUS]: 'To Do',
+			[PROPERTY_PRIORITY]: 'Low',
+		}),
+		createMockBasesEntry(createMockTFile('Task 4.md'), {
+			[PROPERTY_STATUS]: 'Done',
+			[PROPERTY_PRIORITY]: 'Low',
+		}),
+		createMockBasesEntry(createMockTFile('Task 5.md'), {
+			[PROPERTY_STATUS]: 'To Do',
+			[PROPERTY_PRIORITY]: 'High',
+		}),
+	];
+}
+
+function setupSwimlaneController(entries: BasesEntry[], groupBy = PROPERTY_STATUS, swimlaneBy = PROPERTY_PRIORITY) {
+	const controller = createMockQueryController(entries, TEST_PROPERTIES) as any;
+	controller.config.getAsPropertyId = (key: string) => {
+		if (key === 'groupByProperty') return groupBy;
+		if (key === 'swimlaneByProperty') return swimlaneBy;
+		return null;
+	};
+	return controller;
+}
+
+// ── DOM Structure ────────────────────────────────────────────────────────────
+
+describe('Swimlane Rendering - DOM Structure', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		mockSortable();
+		(global as any).Sortable = mockSortable().Sortable;
+		addClosestPolyfill(document.createElement('div'));
+	});
+
+	test('Board gets swimlane modifier class when swimlane property is set', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const board = view.containerEl.querySelector(`.${CSS_CLASSES.BOARD}`);
+		assert.ok(board, 'Board should exist');
+		assert.ok(board.classList.contains(CSS_CLASSES.BOARD_SWIMLANE), 'Board should have swimlane modifier class');
+	});
+
+	test('Flat board class is used when no swimlane property is set', () => {
+		controller = createMockQueryController(createSwimlaneEntries(), TEST_PROPERTIES) as any;
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const board = view.containerEl.querySelector(`.${CSS_CLASSES.BOARD}`);
+		assert.ok(board, 'Board should exist');
+		assert.ok(
+			!board.classList.contains(CSS_CLASSES.BOARD_SWIMLANE),
+			'Board should NOT have swimlane modifier class in flat mode',
+		);
+	});
+
+	test('One swimlane row per unique swimlane property value', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = view.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`);
+		assert.strictEqual(swimlanes.length, 2, 'Should have 2 swimlane rows (High and Low)');
+	});
+
+	test('Each swimlane row has a data-swimlane-value attribute', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`));
+		const values = swimlanes.map((sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE));
+		assert.ok(values.includes('High'), 'High swimlane should exist');
+		assert.ok(values.includes('Low'), 'Low swimlane should exist');
+	});
+
+	test('Each swimlane has a header with drag handle, title, and count', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+		swimlanes.forEach((slEl) => {
+			const header = slEl.querySelector(`.${CSS_CLASSES.SWIMLANE_HEADER}`);
+			assert.ok(header, 'Swimlane should have a header');
+
+			const dragHandle = header!.querySelector(`.${CSS_CLASSES.SWIMLANE_DRAG_HANDLE}`);
+			assert.ok(dragHandle, 'Header should have a drag handle');
+
+			const title = header!.querySelector(`.${CSS_CLASSES.SWIMLANE_TITLE}`);
+			assert.ok(title, 'Header should have a title');
+
+			const count = header!.querySelector(`.${CSS_CLASSES.SWIMLANE_COUNT}`);
+			assert.ok(count, 'Header should have a count badge');
+		});
+	});
+
+	test('Each swimlane has an inner board containing columns', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`);
+		swimlanes.forEach((slEl) => {
+			const innerBoard = slEl.querySelector(`.${CSS_CLASSES.SWIMLANE_BOARD}`);
+			assert.ok(innerBoard, 'Swimlane should have an inner board');
+
+			const columns = innerBoard!.querySelectorAll(`.${CSS_CLASSES.COLUMN}`);
+			assert.ok(columns.length > 0, 'Inner board should have columns');
+		});
+	});
+
+	test('Swimlane count badge reflects number of entries in that row', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`)).find(
+			(sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE) === 'High',
+		);
+
+		assert.ok(highSwimlane, 'High swimlane should exist');
+		const count = highSwimlane!.querySelector(`.${CSS_CLASSES.SWIMLANE_COUNT}`);
+		assert.strictEqual(count?.textContent, '3', 'High swimlane should show 3 cards (Task 1, 2, 5)');
+	});
+});
+
+// ── Card Placement ───────────────────────────────────────────────────────────
+
+describe('Swimlane Rendering - Card Placement', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('Cards appear in the correct swimlane row and column', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		// High / To Do should have 2 cards
+		const highSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="High"]`)!;
+		const highToDoBody = highSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_BODY}`,
+		);
+		assert.ok(highToDoBody, 'High / To Do column body should exist');
+		assert.strictEqual(
+			highToDoBody!.querySelectorAll(`.${CSS_CLASSES.CARD}`).length,
+			2,
+			'High / To Do should have 2 cards (Task 1 and Task 5)',
+		);
+
+		// Low / Done should have 1 card
+		const lowSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="Low"]`)!;
+		const lowDoneBody = lowSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="Done"] .${CSS_CLASSES.COLUMN_BODY}`,
+		);
+		assert.ok(lowDoneBody, 'Low / Done column body should exist');
+		assert.strictEqual(
+			lowDoneBody!.querySelectorAll(`.${CSS_CLASSES.CARD}`).length,
+			1,
+			'Low / Done should have 1 card (Task 4)',
+		);
+	});
+
+	test('Total card count matches total number of entries', () => {
+		const entries = createSwimlaneEntries();
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const allCards = view.containerEl.querySelectorAll(`.${CSS_CLASSES.CARD}`);
+		assert.strictEqual(allCards.length, entries.length, 'All entries should be rendered as cards');
+	});
+
+	test('Entry with missing swimlane property goes to Uncategorized swimlane', () => {
+		const entries: BasesEntry[] = [
+			createMockBasesEntry(createMockTFile('Task A.md'), { [PROPERTY_STATUS]: 'To Do', [PROPERTY_PRIORITY]: 'High' }),
+			createMockBasesEntry(createMockTFile('Task B.md'), { [PROPERTY_STATUS]: 'To Do' }), // no priority
+		];
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const uncategorizedSwimlane = view.containerEl.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="${UNCATEGORIZED_LABEL}"]`,
+		);
+		assert.ok(uncategorizedSwimlane, 'Uncategorized swimlane should be created for missing property');
+
+		const cards = uncategorizedSwimlane!.querySelectorAll(`.${CSS_CLASSES.CARD}`);
+		assert.strictEqual(cards.length, 1, 'Uncategorized swimlane should have exactly 1 card');
+	});
+});
+
+// ── Column Alignment ─────────────────────────────────────────────────────────
+
+describe('Swimlane Rendering - Shared Column Set', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('All swimlane rows show the same set of columns', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlanes = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`));
+		assert.ok(swimlanes.length >= 2, 'Should have at least 2 swimlanes');
+
+		const getColumnValues = (sl: HTMLElement) =>
+			Array.from(sl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`))
+				.map((col) => col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE))
+				.sort();
+
+		const firstRowColumns = getColumnValues(swimlanes[0]);
+		for (let i = 1; i < swimlanes.length; i++) {
+			assert.deepStrictEqual(
+				getColumnValues(swimlanes[i]),
+				firstRowColumns,
+				`Swimlane row ${i} should have the same columns as row 0`,
+			);
+		}
+	});
+
+	test('Remove button is not shown on columns in swimlane mode', () => {
+		const entries: BasesEntry[] = [
+			createMockBasesEntry(createMockTFile('Task 1.md'), {
+				[PROPERTY_STATUS]: 'To Do',
+				[PROPERTY_PRIORITY]: 'High',
+			}),
+			// "Done" column exists only in High, not in Low — but still shown in Low (empty)
+		];
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const removeBtns = view.containerEl.querySelectorAll(`.${CSS_CLASSES.COLUMN_REMOVE_BTN}`);
+		assert.strictEqual(removeBtns.length, 0, 'No remove buttons should appear in swimlane mode');
+	});
+
+	test('Swimlane property hidden from card body properties', () => {
+		const entries: BasesEntry[] = [
+			createMockBasesEntry(createMockTFile('Task 1.md'), {
+				[PROPERTY_STATUS]: 'To Do',
+				[PROPERTY_PRIORITY]: 'High',
+			}),
+		];
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		// Make both properties visible on the card
+		controller.config.getOrder = () => [PROPERTY_STATUS, PROPERTY_PRIORITY];
+		controller.config.getDisplayName = (id: string) => id;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		// The card should not show the swimlane property (PROPERTY_PRIORITY) as a body row
+		const card = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.CARD}`);
+		assert.ok(card, 'Card should exist');
+		const propLabels = Array.from(card!.querySelectorAll(`.${CSS_CLASSES.CARD_PROPERTY_LABEL}`)).map(
+			(el) => el.textContent,
+		);
+		assert.ok(!propLabels.includes(PROPERTY_PRIORITY), 'Swimlane property should be hidden from card body');
+		assert.ok(!propLabels.includes(PROPERTY_STATUS), 'Group-by property should also be hidden from card body');
+	});
+});
+
+// ── Mode Guards ──────────────────────────────────────────────────────────────
+
+describe('Swimlane Mode - Activation Guards', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('Flat mode is used when swimlane property equals group-by property', () => {
+		const entries = createSwimlaneEntries();
+		controller = createMockQueryController(entries, TEST_PROPERTIES) as any;
+		controller.app = app;
+		// Same property for both group-by and swimlane-by
+		controller.config.getAsPropertyId = (key: string) => {
+			if (key === 'groupByProperty') return PROPERTY_STATUS;
+			if (key === 'swimlaneByProperty') return PROPERTY_STATUS; // same!
+			return null;
+		};
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const board = view.containerEl.querySelector(`.${CSS_CLASSES.BOARD}`)!;
+		assert.ok(!board.classList.contains(CSS_CLASSES.BOARD_SWIMLANE), 'Should use flat mode when properties are equal');
+
+		const swimlanes = view.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`);
+		assert.strictEqual(swimlanes.length, 0, 'No swimlane rows should be rendered');
+	});
+
+	test('Switching from flat to swimlane mode re-renders the board', () => {
+		const entries = createSwimlaneEntries();
+
+		// Start in flat mode
+		controller = createMockQueryController(entries, TEST_PROPERTIES) as any;
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		assert.strictEqual(
+			view.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`).length,
+			0,
+			'No swimlane rows in flat mode',
+		);
+
+		// Switch to swimlane mode
+		controller.config.getAsPropertyId = (key: string) => {
+			if (key === 'groupByProperty') return PROPERTY_STATUS;
+			if (key === 'swimlaneByProperty') return PROPERTY_PRIORITY;
+			return null;
+		};
+		triggerDataUpdate(view);
+
+		assert.ok(
+			view.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`).length > 0,
+			'Swimlane rows should appear after switching to swimlane mode',
+		);
+	});
+
+	test('Switching from swimlane to flat mode re-renders the board', () => {
+		const entries = createSwimlaneEntries();
+
+		// Start in swimlane mode
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		assert.ok(
+			view.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`).length > 0,
+			'Should be in swimlane mode initially',
+		);
+
+		// Switch to flat mode
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		triggerDataUpdate(view);
+
+		assert.strictEqual(
+			view.containerEl.querySelectorAll(`.${CSS_CLASSES.SWIMLANE}`).length,
+			0,
+			'Swimlane rows should be gone after switching to flat mode',
+		);
+		assert.ok(
+			view.containerEl.querySelectorAll(`.${CSS_CLASSES.COLUMN}`).length > 0,
+			'Regular columns should exist in flat mode',
+		);
+	});
+});
+
+// ── Column Ordering ───────────────────────────────────────────────────────────
+
+describe('Swimlane Drag and Drop - Column Order Sync', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('Dragging a column in one swimlane updates _prefs.columnOrder', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlaneBoards = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_BOARD}`));
+		assert.ok(swimlaneBoards.length >= 2, 'Should have at least 2 swimlane boards');
+
+		const firstBoard = swimlaneBoards[0];
+		const columns = Array.from(firstBoard.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`));
+		const originalOrder = columns.map((col) => col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE));
+
+		// Reverse column order in the first board's DOM
+		[...columns].reverse().forEach((col) => firstBoard.appendChild(col));
+
+		// Trigger the column drop handler
+		(view as any).handleColumnDropForSwimlane({}, firstBoard);
+
+		const expectedOrder = [...originalOrder].reverse();
+		assert.deepStrictEqual(
+			(view as any)._prefs.columnOrder,
+			expectedOrder,
+			'_prefs.columnOrder should reflect the new column order',
+		);
+	});
+
+	test('Dragging a column in one swimlane syncs order to all other rows', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlaneBoards = Array.from(view.containerEl.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE_BOARD}`));
+		const firstBoard = swimlaneBoards[0];
+		const secondBoard = swimlaneBoards[1];
+
+		// Reverse columns in the first board
+		const columns = Array.from(firstBoard.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`));
+		[...columns].reverse().forEach((col) => firstBoard.appendChild(col));
+
+		(view as any).handleColumnDropForSwimlane({}, firstBoard);
+
+		// The second board should now have the same column order as the first board
+		const firstBoardOrder = Array.from(firstBoard.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`)).map((col) =>
+			col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE),
+		);
+		const secondBoardOrder = Array.from(secondBoard.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.COLUMN}`)).map((col) =>
+			col.getAttribute(DATA_ATTRIBUTES.COLUMN_VALUE),
+		);
+		assert.deepStrictEqual(secondBoardOrder, firstBoardOrder, 'Second board should have same column order as first');
+	});
+});
+
+// ── Swimlane Row Ordering ────────────────────────────────────────────────────
+
+describe('Swimlane Drag and Drop - Row Order', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('Dragging a swimlane row persists the new swimlane order', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const board = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.BOARD}`)!;
+		const swimlanes = Array.from(board.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`));
+		assert.strictEqual(swimlanes.length, 2, 'Should have 2 swimlane rows');
+
+		// Reverse swimlane row order in DOM
+		[...swimlanes].reverse().forEach((sl) => board.appendChild(sl));
+
+		(view as any).handleSwimlaneDrop({});
+
+		const expectedOrder = [...swimlanes].reverse().map((sl) => sl.getAttribute(DATA_ATTRIBUTES.SWIMLANE_VALUE));
+		assert.deepStrictEqual(
+			(view as any)._swimlanePrefs.swimlaneOrder,
+			expectedOrder,
+			'_swimlanePrefs.swimlaneOrder should reflect the new row order',
+		);
+	});
+
+	test('Swimlane order is persisted to config after row drag', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const board = view.containerEl.querySelector<HTMLElement>(`.${CSS_CLASSES.BOARD}`)!;
+		const swimlanes = Array.from(board.querySelectorAll<HTMLElement>(`.${CSS_CLASSES.SWIMLANE}`));
+		[...swimlanes].reverse().forEach((sl) => board.appendChild(sl));
+
+		(view as any).handleSwimlaneDrop({});
+
+		// Config should have been updated
+		const savedOrders = controller.config.get('swimlaneOrders');
+		assert.ok(savedOrders, 'swimlaneOrders should be saved to config');
+		const savedOrder = (savedOrders as any)[PROPERTY_PRIORITY];
+		assert.ok(Array.isArray(savedOrder), 'Should have an array order for the swimlane property');
+		assert.deepStrictEqual(
+			savedOrder,
+			(view as any)._swimlanePrefs.swimlaneOrder,
+			'Config order should match in-memory prefs',
+		);
+	});
+});
+
+// ── Card Drag and Drop ───────────────────────────────────────────────────────
+
+describe('Swimlane Drag and Drop - Card Drop', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('Same swimlane, same column — only updates card order (no frontmatter write)', async () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="High"]`)!;
+		const todoBody = highSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const card = todoBody.querySelector<HTMLElement>(`.${CSS_CLASSES.CARD}`)!;
+
+		await (view as any).handleCardDrop({ item: card, from: todoBody, to: todoBody, oldIndex: 0, newIndex: 1 });
+
+		assert.strictEqual(
+			app.fileManager.processFrontMatter.calls.length,
+			0,
+			'processFrontMatter should NOT be called for a same-column reorder',
+		);
+	});
+
+	test('Same swimlane, different column — only column property updated in frontmatter', async () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="High"]`)!;
+		const todoBody = highSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const doneBody = highSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="Done"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const card = todoBody.querySelector<HTMLElement>(`.${CSS_CLASSES.CARD}`)!;
+
+		await (view as any).handleCardDrop({ item: card, from: todoBody, to: doneBody, oldIndex: 0, newIndex: 0 });
+
+		assert.strictEqual(app.fileManager.processFrontMatter.calls.length, 1, 'processFrontMatter should be called once');
+
+		// Invoke the frontmatter callback and check only the column property changed
+		const callback = app.fileManager.processFrontMatter.calls[0][1];
+		const frontmatter: Record<string, unknown> = { status: 'To Do', priority: 'High' };
+		callback(frontmatter);
+
+		assert.strictEqual(frontmatter['status'], 'Done', 'Column (status) property should be updated');
+		assert.strictEqual(frontmatter['priority'], 'High', 'Swimlane (priority) property should remain unchanged');
+	});
+
+	test('Cross-swimlane drop — both column and swimlane properties updated in frontmatter', async () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="High"]`)!;
+		const lowSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="Low"]`)!;
+
+		const highTodoBody = highSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const lowDoneBody = lowSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="Done"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const card = highTodoBody.querySelector<HTMLElement>(`.${CSS_CLASSES.CARD}`)!;
+
+		await (view as any).handleCardDrop({ item: card, from: highTodoBody, to: lowDoneBody, oldIndex: 0, newIndex: 0 });
+
+		assert.strictEqual(app.fileManager.processFrontMatter.calls.length, 1, 'processFrontMatter should be called once');
+
+		const callback = app.fileManager.processFrontMatter.calls[0][1];
+		const frontmatter: Record<string, unknown> = { status: 'To Do', priority: 'High' };
+		callback(frontmatter);
+
+		assert.strictEqual(frontmatter['status'], 'Done', 'Column (status) property should be updated to Done');
+		assert.strictEqual(frontmatter['priority'], 'Low', 'Swimlane (priority) property should be updated to Low');
+	});
+
+	test('Cross-swimlane, same column — only swimlane property updated in frontmatter', async () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const highSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="High"]`)!;
+		const lowSwimlane = view.containerEl.querySelector<HTMLElement>(`[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="Low"]`)!;
+
+		// Move from High/To Do to Low/To Do (same column, different swimlane)
+		const highTodoBody = highSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const lowTodoBody = lowSwimlane.querySelector<HTMLElement>(
+			`[${DATA_ATTRIBUTES.COLUMN_VALUE}="To Do"] .${CSS_CLASSES.COLUMN_BODY}`,
+		)!;
+		const card = highTodoBody.querySelector<HTMLElement>(`.${CSS_CLASSES.CARD}`)!;
+
+		await (view as any).handleCardDrop({ item: card, from: highTodoBody, to: lowTodoBody, oldIndex: 0, newIndex: 0 });
+
+		assert.strictEqual(app.fileManager.processFrontMatter.calls.length, 1, 'processFrontMatter should be called once');
+
+		const callback = app.fileManager.processFrontMatter.calls[0][1];
+		const frontmatter: Record<string, unknown> = { status: 'To Do', priority: 'High' };
+		callback(frontmatter);
+
+		assert.strictEqual(frontmatter['status'], 'To Do', 'Column (status) property should remain unchanged');
+		assert.strictEqual(frontmatter['priority'], 'Low', 'Swimlane (priority) property should be updated to Low');
+	});
+});
+
+// ── Preference Persistence ────────────────────────────────────────────────────
+
+describe('Swimlane Preferences - Loading and Persistence', () => {
+	let scrollEl: HTMLElement;
+	let controller: any;
+	let app: any;
+
+	beforeEach(() => {
+		scrollEl = createDivWithMethods();
+		app = createMockApp();
+		(global as any).Sortable = mockSortable().Sortable;
+	});
+
+	test('Column order is shared across swimlane rows (same _prefs.columnOrder)', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const columnOrder = (view as any)._prefs.columnOrder as string[];
+		assert.ok(Array.isArray(columnOrder), '_prefs.columnOrder should be an array');
+		assert.ok(columnOrder.length > 0, '_prefs.columnOrder should not be empty');
+		assert.ok(columnOrder.includes('To Do'), 'Column order should include To Do');
+		assert.ok(columnOrder.includes('Done'), 'Column order should include Done');
+	});
+
+	test('Swimlane order is initialised alphabetically on first render', () => {
+		controller = setupSwimlaneController(createSwimlaneEntries());
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const swimlaneOrder = (view as any)._swimlanePrefs.swimlaneOrder as string[];
+		assert.deepStrictEqual(swimlaneOrder, [...swimlaneOrder].sort(), 'Initial swimlane order should be alphabetical');
+	});
+
+	test('Swimlane prefs are reloaded when the swimlane property changes', () => {
+		const entries = createSwimlaneEntries();
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		assert.strictEqual(
+			(view as any)._swimlanePrefsPropertyId,
+			PROPERTY_PRIORITY,
+			'_swimlanePrefsPropertyId should match the swimlane property',
+		);
+
+		// Switch swimlane property to STATUS (different from current PRIORITY)
+		controller.config.getAsPropertyId = (key: string) => {
+			if (key === 'groupByProperty') return PROPERTY_PRIORITY;
+			if (key === 'swimlaneByProperty') return PROPERTY_STATUS;
+			return null;
+		};
+		triggerDataUpdate(view);
+
+		assert.strictEqual(
+			(view as any)._swimlanePrefsPropertyId,
+			PROPERTY_STATUS,
+			'_swimlanePrefsPropertyId should update when the swimlane property changes',
+		);
+	});
+
+	test('Disabling swimlane clears _swimlanePrefsPropertyId', () => {
+		const entries = createSwimlaneEntries();
+		controller = setupSwimlaneController(entries);
+		controller.app = app;
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		assert.strictEqual((view as any)._swimlanePrefsPropertyId, PROPERTY_PRIORITY, 'Should be set in swimlane mode');
+
+		// Disable swimlane
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		triggerDataUpdate(view);
+
+		assert.strictEqual(
+			(view as any)._swimlanePrefsPropertyId,
+			null,
+			'_swimlanePrefsPropertyId should be null after disabling swimlane',
+		);
+	});
+});


### PR DESCRIPTION
_Note: I don't know Typescript so the code was written entirely by Cursor. I wish I were able to submit a more thoroughly reviewed PR, but I thought I'd submit it in case you find the functionality helpful. Thanks for building the plugin in the first place!_

Adds a second grouping dimension to the kanban board. When a **Swimlane by** property is configured, the board switches from a flat column layout to a matrix of horizontal swimlane rows — one per distinct value of the swimlane property — each containing the full set of columns.

### What's new

- **Swimlane by property**: select any property (different from the column group-by property) to split the board into swimlane rows. Cards are placed in the cell matching both their column value and their swimlane value.
- **Shared column set**: all swimlane rows share the same ordered column set, keeping the layout consistent across rows. Colors applied to a column in one swimlane are applied to all swimlanes.
- **Collapse**: Individual swimlanes can be collapsed using the toggle button on the right end.
- **Drag and drop**: cards can be dragged between cells; swimlane rows themselves can be reordered via a drag handle in the row header.
- **Persistent order**: swimlane row order is stored in config (keyed by swimlane property ID) and survives re-renders and reloads.
- **Card order keys**: card order storage uses a composite `swimlaneValue||columnValue` key format so the existing `cardOrders` map works for both flat and swimlane modes without breaking existing saved orders.
- **Activation guard**: swimlane mode is only active when the swimlane property differs from the group-by property — selecting the same property for both axes gracefully falls back to flat mode.

### Implementation notes

- New CSS block under `.obk-board--swimlane` / `.obk-swimlane-*` using the established `.obk-` prefix.
- Separate `_columnBoardSortables` map (keyed by swimlane value) and a `_swimlaneSortable` for row reordering, alongside the existing `columnSortable` used in flat mode.
- Swimlane prefs (`swimlaneOrders`) stored independently from column prefs so neither overwrites the other on property changes.

### Tests

798 lines of new tests covering DOM structure, card placement, shared column sets, activation guards, drag-and-drop (column order sync, row reorder, card drop), and preference persistence.