### PR TITLE
Add quick-add card controls

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,6 +71,7 @@ export const CSS_CLASSES = {
 	COLUMN_DRAG_HANDLE: 'obk-column-drag-handle',
 	COLUMN_DRAGGING: 'obk-column-dragging',
 	COLUMN_GHOST: 'obk-column-ghost',
+	COLUMN_ADD_BTN: 'obk-column-add-btn',
 
 	// Card
 	CARD: 'obk-card',
@@ -97,6 +98,11 @@ export const CSS_CLASSES = {
 
 	// Column remove button (shown only when column is empty)
 	COLUMN_REMOVE_BTN: 'obk-column-remove-btn',
+
+	// Quick add modal
+	QUICK_ADD_FORM: 'obk-quick-add-form',
+	QUICK_ADD_INPUT: 'obk-quick-add-input',
+	QUICK_ADD_ACTIONS: 'obk-quick-add-actions',
 
 	// Color picker
 	COLUMN_COLOR_BTN: 'obk-column-color-btn',

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -6,10 +6,13 @@ import {
 	ListValue,
 	MarkdownRenderer,
 	NullValue,
+	Notice,
+	normalizePath,
 	parsePropertyId,
 	sanitizeHTMLToDom,
 	setIcon,
 } from 'obsidian';
+import type { TFile } from 'obsidian';
 import Sortable from 'sortablejs';
 import {
 	COLOR_PALETTE,
@@ -22,6 +25,7 @@ import {
 	SWIMLANE_KEY_SEPARATOR,
 	UNCATEGORIZED_LABEL,
 } from './constants.ts';
+import { QuickAddModal } from './quickAddModal.ts';
 import type { DebouncedFn } from './utils/debounce.ts';
 import { debounce } from './utils/debounce.ts';
 import { ensureGroupExists, normalizePropertyValue } from './utils/grouping.ts';
@@ -600,7 +604,10 @@ export class KanbanView extends BasesView {
 
 			const bodyEl = laneEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_BODY });
 			orderedColumnValues.forEach((columnValue) => {
-				const columnEl = this.createColumn(columnValue, laneEntries.get(columnValue) || [], { showRemoveButton: false });
+				const columnEl = this.createColumn(columnValue, laneEntries.get(columnValue) || [], {
+					showRemoveButton: false,
+					swimlaneValue: laneValue,
+				});
 				bodyEl.appendChild(columnEl);
 				const cardBody = columnEl.querySelector<HTMLElement>(
 					`.${CSS_CLASSES.COLUMN_BODY}[${DATA_ATTRIBUTES.SORTABLE_CONTAINER}]`,
@@ -919,7 +926,11 @@ export class KanbanView extends BasesView {
 		return flat;
 	}
 
-	private createColumn(value: string, entries: BasesEntry[], options: { showRemoveButton?: boolean } = {}): HTMLElement {
+	private createColumn(
+		value: string,
+		entries: BasesEntry[],
+		options: { showRemoveButton?: boolean; swimlaneValue?: string | null } = {},
+	): HTMLElement {
 		const columnEl = document.createElement('div');
 		columnEl.className = CSS_CLASSES.COLUMN;
 		columnEl.setAttribute(DATA_ATTRIBUTES.COLUMN_VALUE, value);
@@ -944,6 +955,7 @@ export class KanbanView extends BasesView {
 
 		headerEl.createSpan({ text: value, cls: CSS_CLASSES.COLUMN_TITLE });
 		headerEl.createSpan({ text: `${entries.length}`, cls: CSS_CLASSES.COLUMN_COUNT });
+		headerEl.appendChild(this.createAddButton(value, options.swimlaneValue ?? null));
 
 		// Remove button — only shown for flat-mode empty columns.
 		if (entries.length === 0 && options.showRemoveButton !== false) {
@@ -1138,6 +1150,188 @@ export class KanbanView extends BasesView {
 			}
 		};
 		document.addEventListener('click', dismiss);
+	}
+
+	private createAddButton(columnValue: string, swimlaneValue: string | null): HTMLElement {
+		const btn = document.createElement('div');
+		btn.className = CSS_CLASSES.COLUMN_ADD_BTN;
+		btn.setAttribute(
+			'aria-label',
+			swimlaneValue
+				? `Add card to column: ${columnValue} in lane: ${swimlaneValue}`
+				: `Add card to column: ${columnValue}`,
+		);
+		btn.setAttribute('role', 'button');
+		btn.setAttribute('tabindex', '0');
+		setIcon(btn, 'plus');
+		btn.addEventListener('click', (e) => {
+			e.stopPropagation();
+			this.openQuickAdd(columnValue, swimlaneValue);
+		});
+		btn.addEventListener('keydown', (e) => {
+			if (e.key !== 'Enter' && e.key !== ' ') return;
+			e.preventDefault();
+			e.stopPropagation();
+			this.openQuickAdd(columnValue, swimlaneValue);
+		});
+		return btn;
+	}
+
+	private openQuickAdd(columnValue: string, swimlaneValue: string | null): void {
+		if (!this.app) return;
+		new QuickAddModal(this.app, {
+			columnValue,
+			swimlaneValue,
+			onSubmit: (title) => this.createQuickAddCard(title, columnValue, swimlaneValue),
+		}).open();
+	}
+
+	private getWritableFrontmatterPropertyName(propertyId: BasesPropertyId | null): string | null {
+		if (!propertyId) return null;
+		const parsed = parsePropertyId(propertyId);
+		if (parsed.type !== 'note') return null;
+		return parsed.name || null;
+	}
+
+	private getQuickAddFolder(): string | null {
+		const rawFolder = this.config?.get('quickAddFolder');
+		if (typeof rawFolder !== 'string') return null;
+		const folder = normalizePath(rawFolder.trim());
+		return folder ? folder : null;
+	}
+
+	private sanitizeBaseFileName(title: string): string {
+		return title
+			.trim()
+			.replace(/\.md$/i, '')
+			.replace(/[\\/:*?"<>|]/g, '-')
+			.replace(/\s+/g, ' ')
+			.replace(/[.\s]+$/g, '')
+			.trim();
+	}
+
+	private async createQuickAddCard(title: string, columnValue: string, swimlaneValue: string | null): Promise<void> {
+		const baseFileName = this.sanitizeBaseFileName(title);
+		if (!baseFileName) {
+			new Notice('Enter a card title.');
+			return;
+		}
+
+		const columnPropertyName = this.getWritableFrontmatterPropertyName(this._prefsPropertyId);
+		if (!columnPropertyName) {
+			new Notice('Quick add needs a writable note property for columns.');
+			return;
+		}
+
+		const swimlanePropertyName = swimlaneValue
+			? this.getWritableFrontmatterPropertyName(this._prefsSwimlanePropertyId)
+			: null;
+		if (swimlaneValue && !swimlanePropertyName) {
+			new Notice('Quick add needs a writable note property for swimlanes.');
+			return;
+		}
+
+		const quickAddFolder = this.getQuickAddFolder();
+		if (quickAddFolder && !this.app?.vault.getFolderByPath(quickAddFolder)) {
+			new Notice(`Quick add folder not found: ${quickAddFolder}`);
+			return;
+		}
+		const createdFilePaths =
+			quickAddFolder && this.app?.vault ? new Set(this.app.vault.getMarkdownFiles().map((file) => file.path)) : null;
+
+		const setFrontmatter = (frontmatter: Record<string, unknown>): void => {
+			if (columnValue === UNCATEGORIZED_LABEL) {
+				delete frontmatter[columnPropertyName];
+			} else {
+				frontmatter[columnPropertyName] = columnValue;
+			}
+
+			if (!swimlaneValue || !swimlanePropertyName) return;
+			if (swimlaneValue === UNCATEGORIZED_LABEL) {
+				delete frontmatter[swimlanePropertyName];
+			} else {
+				frontmatter[swimlanePropertyName] = swimlaneValue;
+			}
+		};
+
+		try {
+			await this.createFileForView(baseFileName, setFrontmatter);
+			if (quickAddFolder && createdFilePaths) {
+				await this.moveCreatedCardToFolder(createdFilePaths, baseFileName, quickAddFolder);
+			}
+			this.closeNativeNewItemPopover();
+		} catch (error) {
+			console.error('Error creating kanban card:', error);
+			new Notice('Could not create card.');
+		}
+	}
+
+	private closeNativeNewItemPopover(): void {
+		const closePopovers = () => {
+			const popovers = Array.from(document.querySelectorAll<HTMLElement>('.bases-new-item-popover'));
+			if (popovers.length === 0) return;
+
+			document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, cancelable: true }));
+			document.body.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+			popovers.forEach((popover) => {
+				popover.remove();
+			});
+		};
+
+		closePopovers();
+		globalThis.requestAnimationFrame(closePopovers);
+		for (const delay of [50, 250, 1000]) {
+			globalThis.setTimeout(closePopovers, delay);
+		}
+	}
+
+	private getCreatedMarkdownFile(previousPaths: Set<string>, baseFileName: string): TFile | null {
+		if (!this.app?.vault) return null;
+
+		const createdFiles = this.app.vault.getMarkdownFiles().filter((file) => !previousPaths.has(file.path));
+		if (createdFiles.length === 0) return null;
+
+		const preferredBasename = baseFileName.split('/').pop() ?? baseFileName;
+		return createdFiles.find((file) => file.basename === preferredBasename) ?? createdFiles[0] ?? null;
+	}
+
+	private getAvailablePath(folder: string, fileName: string): string {
+		const extension = fileName.toLowerCase().endsWith('.md') ? '.md' : '';
+		const basename = extension ? fileName.slice(0, -extension.length) : fileName;
+		let candidate = normalizePath(`${folder}/${extension ? fileName : `${fileName}.md`}`);
+		let counter = 1;
+
+		while (this.app?.vault.getAbstractFileByPath(candidate)) {
+			candidate = normalizePath(`${folder}/${basename} ${counter}.md`);
+			counter++;
+		}
+
+		return candidate;
+	}
+
+	private async moveCreatedCardToFolder(
+		previousPaths: Set<string>,
+		baseFileName: string,
+		folder: string,
+	): Promise<void> {
+		if (!this.app?.vault || !this.app.fileManager) return;
+
+		const targetFolder = this.app.vault.getFolderByPath(folder);
+		if (!targetFolder) {
+			new Notice(`Quick add folder not found: ${folder}`);
+			return;
+		}
+
+		const createdFile = this.getCreatedMarkdownFile(previousPaths, baseFileName);
+		if (!createdFile) {
+			new Notice(`Created card, but could not move it to ${folder}.`);
+			return;
+		}
+
+		const targetPath = this.getAvailablePath(folder, createdFile.name);
+		if (targetPath === createdFile.path) return;
+
+		await this.app.fileManager.renameFile(createdFile, targetPath);
 	}
 
 	private createRemoveButton(value: string, columnEl: HTMLElement): HTMLElement {
@@ -1428,6 +1622,12 @@ export class KanbanView extends BasesView {
 				key: 'swimlaneByProperty',
 				filter: (prop: string) => !prop.startsWith('file.'),
 				placeholder: 'Optional: horizontal grouping',
+			},
+			{
+				displayName: 'New card folder',
+				type: 'folder',
+				key: 'quickAddFolder',
+				placeholder: 'Default: base file folder',
 			},
 			{
 				displayName: 'Card title property',

--- a/src/quickAddModal.ts
+++ b/src/quickAddModal.ts
@@ -1,0 +1,77 @@
+import type { App } from 'obsidian';
+import { Modal, TextComponent } from 'obsidian';
+import { CSS_CLASSES } from './constants.ts';
+
+export interface QuickAddModalOptions {
+	columnValue: string;
+	swimlaneValue: string | null;
+	onSubmit: (title: string) => Promise<void> | void;
+}
+
+export class QuickAddModal extends Modal {
+	private input: TextComponent | null = null;
+	private submitting = false;
+
+	constructor(
+		app: App,
+		private readonly options: QuickAddModalOptions,
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { columnValue, swimlaneValue } = this.options;
+		this.setTitle(swimlaneValue ? `Add card to ${swimlaneValue} / ${columnValue}` : `Add card to ${columnValue}`);
+
+		const formEl = this.contentEl.createEl('form', { cls: CSS_CLASSES.QUICK_ADD_FORM });
+		this.input = new TextComponent(formEl);
+		this.input.setPlaceholder('Card title');
+		this.input.inputEl.classList.add(CSS_CLASSES.QUICK_ADD_INPUT);
+
+		const actionsEl = formEl.createDiv({ cls: CSS_CLASSES.QUICK_ADD_ACTIONS });
+		const cancelBtn = actionsEl.createEl('button', {
+			text: 'Cancel',
+			attr: { type: 'button' },
+		});
+		const submitBtn = actionsEl.createEl('button', {
+			text: 'Add',
+			cls: 'mod-cta',
+			attr: { type: 'submit' },
+		});
+
+		cancelBtn.addEventListener('click', () => this.close());
+		formEl.addEventListener('submit', (evt) => {
+			evt.preventDefault();
+			void this.submit(submitBtn);
+		});
+
+		requestAnimationFrame(() => this.input?.inputEl.focus());
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+		this.input = null;
+		this.submitting = false;
+	}
+
+	private async submit(submitBtn: HTMLButtonElement): Promise<void> {
+		if (this.submitting) return;
+
+		const title = this.input?.getValue().trim() ?? '';
+		if (!title) {
+			this.input?.inputEl.focus();
+			return;
+		}
+
+		this.submitting = true;
+		submitBtn.disabled = true;
+		try {
+			await this.options.onSubmit(title);
+			this.close();
+		} catch (error) {
+			this.submitting = false;
+			submitBtn.disabled = false;
+			throw error;
+		}
+	}
+}

--- a/styles.css
+++ b/styles.css
@@ -378,6 +378,48 @@
 	border-radius: 12px;
 }
 
+.obk-column-add-btn,
+.obk-column-remove-btn {
+	width: 24px;
+	height: 24px;
+	border-radius: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	color: var(--text-muted);
+	cursor: pointer;
+	flex-shrink: 0;
+	transition:
+		background 0.1s ease,
+		color 0.1s ease,
+		opacity 0.1s ease;
+}
+
+.obk-column-add-btn {
+	opacity: 0.55;
+}
+
+.obk-column:hover .obk-column-add-btn,
+.obk-column-add-btn:focus-visible {
+	opacity: 1;
+}
+
+.obk-column-add-btn:hover,
+.obk-column-remove-btn:hover {
+	color: var(--text-normal);
+	background: var(--background-modifier-hover);
+}
+
+.obk-column-add-btn .svg-icon {
+	width: 16px;
+	height: 16px;
+}
+
+.obk-column-remove-btn {
+	font-size: 18px;
+	line-height: 1;
+}
+
 .obk-column-body {
 	flex: 1;
 	overflow-y: auto;
@@ -509,6 +551,22 @@
 .obk-card-property-value p {
 	display: inline;
 	margin: 0;
+}
+
+.obk-quick-add-form {
+	display: flex;
+	flex-direction: column;
+	gap: 14px;
+}
+
+.obk-quick-add-input {
+	width: 100%;
+}
+
+.obk-quick-add-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
 }
 
 /* Drag and Drop States */

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -206,10 +206,12 @@ export function createMockFn(): MockFn {
 // Mock App
 export function createMockApp(imageFiles: Record<string, { path: string }> = {}): App & {
 	workspace: { openLinkText: MockFn };
-	fileManager: { processFrontMatter: MockFn };
+	fileManager: { processFrontMatter: MockFn; renameFile: MockFn };
 } {
 	const openLinkText = createMockFn();
 	const processFrontMatter = createMockFn();
+	const renameFile = createMockFn();
+	const markdownFiles: any[] = [];
 
 	return {
 		workspace: {
@@ -217,11 +219,15 @@ export function createMockApp(imageFiles: Record<string, { path: string }> = {})
 		} as any,
 		fileManager: {
 			processFrontMatter,
+			renameFile,
 		} as any,
 		metadataCache: {
 			getFirstLinkpathDest: (linkpath: string, _sourcePath: string) => imageFiles[linkpath] ?? null,
 		} as any,
 		vault: {
+			getMarkdownFiles: () => markdownFiles,
+			getFolderByPath: (path: string) => ({ path, name: path.split('/').pop() ?? path }),
+			getAbstractFileByPath: (path: string) => markdownFiles.find((file) => file.path === path) ?? null,
 			getResourcePath: (file: { path: string }) => `app://fake/${file.path}`,
 		} as any,
 	} as any;

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { beforeEach, describe, test } from 'node:test';
 import type { BasesPropertyId } from 'obsidian';
-import { UNCATEGORIZED_LABEL } from '../src/constants.ts';
+import { CSS_CLASSES, UNCATEGORIZED_LABEL } from '../src/constants.ts';
 import { isCardOrders, KanbanView, renderPropertyValue } from '../src/kanbanView.ts';
 import { normalizePropertyValue } from '../src/utils/grouping.ts';
 import {
@@ -251,9 +251,177 @@ describe('Data Rendering - Column Rendering', () => {
 		const count = header?.querySelector('.obk-column-count');
 		assert.ok(count, 'Column count should exist');
 
+		const addBtn = header?.querySelector(`.${CSS_CLASSES.COLUMN_ADD_BTN}`);
+		assert.ok(addBtn, 'Column quick add button should exist');
+
 		const body = firstColumn.querySelector('.obk-column-body');
 		assert.ok(body, 'Column body should exist');
 		assert.ok(body?.getAttribute('data-sortable-container'), 'Column body should have data-sortable-container attribute');
+	});
+
+	test('column quick add button has an accessible label and plus icon', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const doingColumn = view.containerEl.querySelector('[data-column-value="Doing"]');
+		const addBtn = doingColumn?.querySelector(`.${CSS_CLASSES.COLUMN_ADD_BTN}`);
+		assert.ok(addBtn, 'Doing column should have a quick add button');
+		assert.strictEqual(addBtn?.getAttribute('aria-label'), 'Add card to column: Doing');
+		assert.strictEqual(addBtn?.getAttribute('tabindex'), '0');
+		assert.ok(addBtn?.querySelector('[data-icon="plus"]'), 'Quick add button should render the plus icon');
+	});
+
+	test('quick add creates a file with the selected column property', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
+		]);
+	});
+
+	test('quick add omits the column property for Uncategorized', async () => {
+		const entries = createEntriesWithEmptyValues();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		await (view as any).createQuickAddCard('New Task', UNCATEGORIZED_LABEL, null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [{ baseFileName: 'New Task', frontmatter: {} }]);
+	});
+
+	test('quick add sets both column and swimlane properties when used inside a lane', async () => {
+		const entries = createEntriesWithMixedProperties();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = (key: string) => {
+			if (key === 'groupByProperty') return PROPERTY_STATUS;
+			if (key === 'swimlaneByProperty') return PROPERTY_PRIORITY;
+			return null;
+		};
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		await (view as any).createQuickAddCard('New Lane Task', 'Doing', 'High');
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'New Lane Task', frontmatter: { status: 'Doing', priority: 'High' } },
+		]);
+	});
+
+	test('quick add moves the created file to the configured folder', async () => {
+		const entries = createEntriesWithStatus();
+		const createdFile = createMockTFile('dashboards/New Task.md');
+		let markdownFiles = [createMockTFile('dashboards/maintenance-board.base')];
+
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'energy');
+
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
+		(app.vault as any).getFolderByPath = (path: string) => (path === 'energy' ? { path, name: 'energy' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			markdownFiles = [...markdownFiles, createdFile];
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
+		]);
+		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
+	});
+
+	test('quick add closes the native Base new item popover', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const popover = document.createElement('div');
+		popover.className = 'bases-new-item-popover';
+		document.body.appendChild(popover);
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.strictEqual(document.querySelector('.bases-new-item-popover'), null);
+	});
+
+	test('quick add closes the native Base new item popover when Obsidian opens it after creation', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async () => {
+			window.setTimeout(() => {
+				const popover = document.createElement('div');
+				popover.className = 'bases-new-item-popover';
+				document.body.appendChild(popover);
+			}, 200);
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+		await new Promise((resolve) => window.setTimeout(resolve, 300));
+
+		assert.strictEqual(document.querySelector('.bases-new-item-popover'), null);
+	});
+
+	test('quick add does not create a file when configured folder is missing', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'missing');
+		(app.vault as any).getFolderByPath = (): null => null;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, []);
 	});
 });
 

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -167,6 +167,10 @@ describe('View Options', () => {
 		assert.ok(byKey.wrapPropertyValues, 'wrapPropertyValues option should exist');
 		assert.strictEqual(byKey.wrapPropertyValues.displayName, 'Wrap property values');
 		assert.strictEqual(byKey.wrapPropertyValues.type, 'toggle');
+
+		assert.ok(byKey.quickAddFolder, 'quickAddFolder option should exist');
+		assert.strictEqual(byKey.quickAddFolder.displayName, 'New card folder');
+		assert.strictEqual(byKey.quickAddFolder.type, 'folder');
 	});
 
 	test('Property filter excludes file.* properties', () => {

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -43,6 +43,13 @@ export interface App {
 	};
 	fileManager: {
 		processFrontMatter(file: TFile, fn: (frontmatter: any) => void | Promise<void>): Promise<void>;
+		renameFile(file: TFile, newPath: string): Promise<void>;
+	};
+	vault: {
+		getMarkdownFiles(): TFile[];
+		getFolderByPath(path: string): { path: string; name: string } | null;
+		getAbstractFileByPath(path: string): TFile | null;
+		getResourcePath(file: { path: string }): string;
 	};
 }
 
@@ -57,6 +64,7 @@ export abstract class BasesView {
 		getOrder(): BasesPropertyId[];
 		getDisplayName(propertyId: BasesPropertyId): string;
 	};
+	createFileForViewCalls: Array<{ baseFileName: string; frontmatter: Record<string, unknown> }> = [];
 
 	constructor(controller: QueryController) {
 		this.app = controller.app;
@@ -67,6 +75,15 @@ export abstract class BasesView {
 
 	abstract onDataUpdated(): void;
 	onClose?(): void;
+
+	async createFileForView(
+		baseFileName: string,
+		frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+	): Promise<void> {
+		const frontmatter: Record<string, unknown> = {};
+		frontmatterProcessor?.(frontmatter);
+		this.createFileForViewCalls.push({ baseFileName, frontmatter });
+	}
 }
 
 export class Plugin {
@@ -224,15 +241,110 @@ export class Keymap {
 	}
 }
 
-export function parsePropertyId(propertyId: BasesPropertyId): { name: string; source?: string } {
+export class Modal {
+	app: App;
+	containerEl: HTMLElement;
+	modalEl: HTMLElement;
+	titleEl: HTMLElement;
+	contentEl: HTMLElement;
+	scope = {};
+
+	constructor(app: App) {
+		this.app = app;
+		this.containerEl = document.createElement('div');
+		this.containerEl.className = 'modal-container';
+		this.modalEl = this.containerEl.createDiv({ cls: 'modal' });
+		this.titleEl = this.modalEl.createDiv({ cls: 'modal-title' });
+		this.contentEl = this.modalEl.createDiv({ cls: 'modal-content' });
+	}
+
+	open(): void {
+		document.body.appendChild(this.containerEl);
+		void this.onOpen();
+	}
+
+	close(): void {
+		this.onClose();
+		this.containerEl.remove();
+	}
+
+	onOpen(): Promise<void> | void {}
+
+	onClose(): void {}
+
+	setTitle(title: string): this {
+		this.titleEl.textContent = title;
+		return this;
+	}
+
+	setContent(content: string | DocumentFragment): this {
+		this.contentEl.empty();
+		if (typeof content === 'string') {
+			this.contentEl.textContent = content;
+		} else {
+			this.contentEl.appendChild(content);
+		}
+		return this;
+	}
+}
+
+export class TextComponent {
+	inputEl: HTMLInputElement;
+
+	constructor(containerEl: HTMLElement) {
+		this.inputEl = document.createElement('input');
+		this.inputEl.type = 'text';
+		containerEl.appendChild(this.inputEl);
+	}
+
+	getValue(): string {
+		return this.inputEl.value;
+	}
+
+	setValue(value: string): this {
+		this.inputEl.value = value;
+		return this;
+	}
+
+	setPlaceholder(placeholder: string): this {
+		this.inputEl.placeholder = placeholder;
+		return this;
+	}
+}
+
+export class Notice {
+	static notices: Array<string | DocumentFragment> = [];
+
+	constructor(
+		public message: string | DocumentFragment,
+		_duration?: number,
+	) {
+		Notice.notices.push(message);
+	}
+
+	setMessage(message: string | DocumentFragment): this {
+		this.message = message;
+		Notice.notices.push(message);
+		return this;
+	}
+
+	hide(): void {}
+}
+
+export function normalizePath(path: string): string {
+	return path.replace(/\\/g, '/').replace(/\/+/g, '/').replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+export function parsePropertyId(propertyId: BasesPropertyId): { name: string; type: string } {
 	const parts = propertyId.split('.');
 	if (parts.length > 1) {
 		return {
 			name: parts.slice(1).join('.'),
-			source: parts[0],
+			type: parts[0],
 		};
 	}
 	return {
 		name: propertyId,
+		type: 'note',
 	};
 }


### PR DESCRIPTION
## Summary
- add a plus button to each kanban column header for quick card creation
- add a small title-only quick-add modal that uses the native Bases file creation flow
- add an optional New card folder view option so created cards can be moved into a configured folder
- dismiss the native Bases new-item popover after quick-add creates the card

## Notes
This PR is stacked on top of #41 (swimlanes). The branch is also pushed to the fork as edwindoit:codex/quick-add-cards so the feature remains available there even if upstream chooses not to merge it.

## Testing
- npm run format
- npm run lint
- npm run build
- npm test
- synced into local Obsidian vault and verified quick-add buttons/options are present
