### PR TITLE
Respect Base sort order in kanban cards

### DIFF
--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -395,9 +395,11 @@ export class KanbanView extends BasesView {
 			const groupedEntries = groupedByLane
 				? this.flattenLanes(groupedByLane)
 				: this.groupEntriesByProperty(entries, this.groupByPropertyId);
+			const sortActive = this.hasActiveSort();
 
-			// Apply saved card order within each column / lane×column cell.
-			if (groupedByLane) {
+			// Apply manual card order only when the Base itself is not sorted.
+			// When sorting is active, Bases has already ordered `entries`.
+			if (!sortActive && groupedByLane) {
 				groupedByLane.forEach((columns, laneValue) => {
 					columns.forEach((cellEntries, columnValue) => {
 						const savedOrder = this._prefs.cardOrders[this.cardOrderKey(laneValue, columnValue)];
@@ -406,7 +408,7 @@ export class KanbanView extends BasesView {
 						}
 					});
 				});
-			} else {
+			} else if (!sortActive) {
 				groupedEntries.forEach((columnEntries, value) => {
 					const savedOrder = this._prefs.cardOrders[this.cardOrderKey(null, value)];
 					if (savedOrder) {
@@ -1253,21 +1255,28 @@ export class KanbanView extends BasesView {
 
 		const oldKey = this.cardOrderKey(oldLaneValue, oldColumnValue ?? '');
 		const newKey = this.cardOrderKey(newLaneValue, newColumnValue);
+		const sortActive = this.hasActiveSort();
 
 		// Same cell reorder: update prefs and persist
 		if (oldLaneValue === newLaneValue && oldColumnValue === newColumnValue) {
+			if (sortActive) {
+				this.render();
+				return;
+			}
 			this._prefs.cardOrders[newKey] = getColumnPaths(evt.to);
 			this._persistPrefs();
 			return;
 		}
 
 		// Cross-cell drop: capture DOM order for both source and destination
-		if (oldColumnEl instanceof HTMLElement && oldColumnValue) {
-			const oldBody = oldColumnEl.querySelector(`.${CSS_CLASSES.COLUMN_BODY}`);
-			if (oldBody) this._prefs.cardOrders[oldKey] = getColumnPaths(oldBody);
+		if (!sortActive) {
+			if (oldColumnEl instanceof HTMLElement && oldColumnValue) {
+				const oldBody = oldColumnEl.querySelector(`.${CSS_CLASSES.COLUMN_BODY}`);
+				if (oldBody) this._prefs.cardOrders[oldKey] = getColumnPaths(oldBody);
+			}
+			this._prefs.cardOrders[newKey] = getColumnPaths(evt.to);
+			this._persistPrefs();
 		}
-		this._prefs.cardOrders[newKey] = getColumnPaths(evt.to);
-		this._persistPrefs();
 
 		const entry = this._entryMap.get(entryPath);
 		if (!entry) {
@@ -1331,6 +1340,13 @@ export class KanbanView extends BasesView {
 	private reapplyActiveCard(): void {
 		if (!this._activeCardPath) return;
 		this.findCardEl(this._activeCardPath)?.classList.add(CSS_CLASSES.CARD_ACTIVE);
+	}
+
+	private hasActiveSort(): boolean {
+		const sortConfig = this.config?.getSort();
+		if (Array.isArray(sortConfig)) return sortConfig.length > 0;
+		if (!sortConfig || typeof sortConfig !== 'object') return Boolean(sortConfig);
+		return Object.keys(sortConfig).length > 0;
 	}
 
 	private getOrderedColumnValues(liveValues: string[]): string[] {

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -168,6 +168,7 @@ export function createMockQueryController(
 		config: {
 			getAsPropertyId: (_key: string): BasesPropertyId | null => null,
 			getOrder: (): string[] => [],
+			getSort: (): unknown => configData.sort ?? [],
 			getDisplayName: (propertyId: string): string => propertyId,
 			get: (key: string): unknown => configData[key] ?? null,
 			set: (key: string, value: unknown): void => {

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -2095,6 +2095,40 @@ describe('Card Order - Persistence', () => {
 		assert.strictEqual(columnOrder[1], cards[0].getAttribute('data-entry-path'), 'Original first card should be second');
 	});
 
+	test('Same-column drop does not save card order while Base sort is active', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const toDoColumn = Array.from(view.containerEl.querySelectorAll('.obk-column')).find(
+			(col) => col.getAttribute('data-column-value') === 'To Do',
+		) as HTMLElement;
+		const toDoBody = toDoColumn.querySelector('.obk-column-body') as HTMLElement;
+		const cards = Array.from(toDoBody.querySelectorAll('.obk-card')) as HTMLElement[];
+
+		toDoBody.insertBefore(cards[1], cards[0]);
+
+		const mockEvent = { item: cards[1], from: toDoBody, to: toDoBody, oldIndex: 1, newIndex: 0 };
+		await (view as any).handleCardDrop(mockEvent);
+
+		const savedOrders = controller.config.get('cardOrders') as Record<string, Record<string, string[]>> | null;
+		assert.strictEqual(
+			savedOrders?.[PROPERTY_STATUS]?.['To Do'],
+			undefined,
+			'To Do card order should not be saved when Base sort is active',
+		);
+
+		const cardPaths = Array.from(toDoBody.querySelectorAll('.obk-card')).map((c) => c.getAttribute('data-entry-path'));
+		assert.strictEqual(cardPaths[0], 'Task 1.md', 'First card should snap back to sorted data order');
+		assert.strictEqual(cardPaths[1], 'Task 2.md', 'Second card should snap back to sorted data order');
+	});
+
 	test('Same-column drop does not call processFrontMatter', async () => {
 		const entries = createEntriesWithStatus();
 		controller = createMockQueryController(entries, TEST_PROPERTIES);
@@ -2181,6 +2215,28 @@ describe('Card Order - Persistence', () => {
 
 		assert.strictEqual(cardPaths[0], 'Task 2.md', 'First card should be Task 2 per saved order');
 		assert.strictEqual(cardPaths[1], 'Task 1.md', 'Second card should be Task 1 per saved order');
+	});
+
+	test('Base sort takes precedence over saved card order', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+		controller.config.set('cardOrders', { [PROPERTY_STATUS]: { 'To Do': ['Task 2.md', 'Task 1.md'] } });
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const toDoColumn = Array.from(view.containerEl.querySelectorAll('.obk-column')).find(
+			(col) => col.getAttribute('data-column-value') === 'To Do',
+		) as HTMLElement;
+		const cardPaths = Array.from(toDoColumn.querySelectorAll('.obk-card')).map((c) => c.getAttribute('data-entry-path'));
+
+		assert.strictEqual(cardPaths[0], 'Task 1.md', 'First card should follow the sorted data order');
+		assert.strictEqual(cardPaths[1], 'Task 2.md', 'Second card should follow the sorted data order');
 	});
 
 	test('Re-render applies saved card order (patch path)', () => {

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -32,7 +32,10 @@ export interface QueryController {
 	config: {
 		getAsPropertyId(key: string): BasesPropertyId | null;
 		getOrder(): BasesPropertyId[];
+		getSort?(): unknown;
 		getDisplayName(propertyId: BasesPropertyId): string;
+		get?(key: string): unknown;
+		set?(key: string, value: unknown): void;
 	};
 	app?: App;
 }
@@ -55,7 +58,10 @@ export abstract class BasesView {
 	config?: {
 		getAsPropertyId(key: string): BasesPropertyId | null;
 		getOrder(): BasesPropertyId[];
+		getSort?(): unknown;
 		getDisplayName(propertyId: BasesPropertyId): string;
+		get?(key: string): unknown;
+		set?(key: string, value: unknown): void;
 	};
 
 	constructor(controller: QueryController) {


### PR DESCRIPTION
## Summary
- skip persisted manual card order when the Base has an active sort
- avoid saving same-column card order while sorted so future renders keep following the Base sort
- add regression coverage for sorted boards with saved cardOrders

## Test plan
- npm test
- npm run typecheck
- npm run lint
- npm run format:check