### PR TITLE
Warn when sorted boards reject card reordering

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,8 +26,7 @@ export type ColorName = (typeof COLOR_PALETTE)[number]['name'];
 export const SORTABLE_GROUP = 'obk-columns';
 
 /** Notice shown when Base sorting prevents manual card ordering */
-export const SORTED_CARD_ORDER_NOTICE =
-	'⚠️ Sort is active. Clear it to manually reorder cards within a column.';
+export const SORTED_CARD_ORDER_NOTICE = '⚠️ Sort is active. Clear it to manually reorder cards within a column.';
 
 /** Data attribute names */
 export const DATA_ATTRIBUTES = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,7 +26,8 @@ export type ColorName = (typeof COLOR_PALETTE)[number]['name'];
 export const SORTABLE_GROUP = 'obk-columns';
 
 /** Notice shown when Base sorting prevents manual card ordering */
-export const SORTED_CARD_ORDER_NOTICE = '⚠️ Sort is active. Clear it to drag and drop.';
+export const SORTED_CARD_ORDER_NOTICE =
+	'⚠️ Sort is active. Clear it to manually reorder cards within a column.';
 
 /** Data attribute names */
 export const DATA_ATTRIBUTES = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,9 @@ export type ColorName = (typeof COLOR_PALETTE)[number]['name'];
 /** Sortable.js group name for kanban columns */
 export const SORTABLE_GROUP = 'obk-columns';
 
+/** Notice shown when Base sorting prevents manual card ordering */
+export const SORTED_CARD_ORDER_NOTICE = '⚠️ Sort is active. Clear it to drag and drop.';
+
 /** Data attribute names */
 export const DATA_ATTRIBUTES = {
 	COLUMN_VALUE: 'data-column-value',

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -1595,7 +1595,7 @@ export class KanbanView extends BasesView {
 
 			// Keep same-column sorting enabled so Sortable can report whether the
 			// user actually tried to move a card. Sorted boards snap back in
-			// handleCardDrop after showing an action-specific notice.
+			// handleCardDrop after optionally showing an action-specific notice.
 			sort: true,
 
 			dragClass: CSS_CLASSES.CARD_DRAGGING,

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -23,6 +23,7 @@ import {
 	HOVER_LINK_SOURCE_ID,
 	SORTABLE_CONFIG,
 	SORTABLE_GROUP,
+	SORTED_CARD_ORDER_NOTICE,
 	SWIMLANE_KEY_SEPARATOR,
 	UNCATEGORIZED_LABEL,
 } from './constants.ts';
@@ -1592,6 +1593,11 @@ export class KanbanView extends BasesView {
 			delayOnTouchOnly: true,
 			touchStartThreshold: SORTABLE_CONFIG.TOUCH_START_THRESHOLD,
 
+			// Keep same-column sorting enabled so Sortable can report whether the
+			// user actually tried to move a card. Sorted boards snap back in
+			// handleCardDrop after showing an action-specific notice.
+			sort: true,
+
 			dragClass: CSS_CLASSES.CARD_DRAGGING,
 			ghostClass: CSS_CLASSES.CARD_GHOST,
 			chosenClass: CSS_CLASSES.CARD_CHOSEN,
@@ -1666,6 +1672,9 @@ export class KanbanView extends BasesView {
 		// Same cell reorder: update prefs and persist
 		if (oldLaneValue === newLaneValue && oldColumnValue === newColumnValue) {
 			if (sortActive) {
+				if (this.didSortableIndexChange(evt)) {
+					new Notice(SORTED_CARD_ORDER_NOTICE, 4000);
+				}
 				this.render();
 				return;
 			}
@@ -1792,6 +1801,16 @@ export class KanbanView extends BasesView {
 	private reapplyActiveCard(): void {
 		if (!this._activeCardPath) return;
 		this.findCardEl(this._activeCardPath)?.classList.add(CSS_CLASSES.CARD_ACTIVE);
+	}
+
+	private didSortableIndexChange(evt: Sortable.SortableEvent): boolean {
+		if (evt.oldDraggableIndex !== undefined || evt.newDraggableIndex !== undefined) {
+			return evt.oldDraggableIndex !== evt.newDraggableIndex;
+		}
+		if (evt.oldIndex !== undefined || evt.newIndex !== undefined) {
+			return evt.oldIndex !== evt.newIndex;
+		}
+		return false;
 	}
 
 	private hasActiveSort(): boolean {

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -1,7 +1,15 @@
 import assert from 'node:assert';
 import { beforeEach, describe, test } from 'node:test';
+import { Notice } from 'obsidian';
 import type { BasesPropertyId } from 'obsidian';
-import { CSS_CLASSES, HOVER_LINK_SOURCE_ID, SORTABLE_CONFIG, UNCATEGORIZED_LABEL } from '../src/constants.ts';
+import {
+	CSS_CLASSES,
+	HOVER_LINK_SOURCE_ID,
+	SORTABLE_CONFIG,
+	SORTABLE_GROUP,
+	SORTED_CARD_ORDER_NOTICE,
+	UNCATEGORIZED_LABEL,
+} from '../src/constants.ts';
 import { isCardOrders, KanbanView, renderPropertyValue } from '../src/kanbanView.ts';
 import { normalizePropertyValue } from '../src/utils/grouping.ts';
 import {
@@ -43,6 +51,8 @@ import {
 } from './helpers.ts';
 
 setupTestEnvironment();
+
+const noticeMessages = (): unknown[] => (Notice as unknown as { notices: unknown[] }).notices;
 
 describe('KanbanView Initialization', () => {
 	let scrollEl: HTMLElement;
@@ -965,6 +975,48 @@ describe('Drag and Drop - Sortable Initialization', () => {
 				SORTABLE_CONFIG.TOUCH_START_THRESHOLD,
 				'Card Sortable should have touchStartThreshold configured',
 			);
+		});
+	});
+
+	test('Card Sortable instances keep intra-column sorting enabled while Base sort is active', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const viewInstances = Array.from((view as any)._columnSortables.values());
+		assert.ok(viewInstances.length > 0, 'Sortable instances should be created');
+
+		viewInstances.forEach((instance: any) => {
+			assert.strictEqual(
+				instance.options.sort,
+				true,
+				'Card Sortable should allow same-column drag attempts so a sorted board can warn on reorder',
+			);
+			assert.strictEqual(instance.options.group, SORTABLE_GROUP, 'Card Sortable should still allow cross-column dragging');
+		});
+	});
+
+	test('Card Sortable instances allow intra-column sorting when Base sort is inactive', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const viewInstances = Array.from((view as any)._columnSortables.values());
+		assert.ok(viewInstances.length > 0, 'Sortable instances should be created');
+
+		viewInstances.forEach((instance: any) => {
+			assert.strictEqual(instance.options.sort, true, 'Card Sortable should allow same-column sorting');
 		});
 	});
 });
@@ -2490,6 +2542,7 @@ describe('Card Order - Persistence', () => {
 
 		toDoBody.insertBefore(cards[1], cards[0]);
 
+		const noticeStart = noticeMessages().length;
 		const mockEvent = { item: cards[1], from: toDoBody, to: toDoBody, oldIndex: 1, newIndex: 0 };
 		await (view as any).handleCardDrop(mockEvent);
 
@@ -2499,10 +2552,98 @@ describe('Card Order - Persistence', () => {
 			undefined,
 			'To Do card order should not be saved when Base sort is active',
 		);
+		assert.deepStrictEqual(noticeMessages().slice(noticeStart), [SORTED_CARD_ORDER_NOTICE]);
 
 		const cardPaths = Array.from(toDoBody.querySelectorAll('.obk-card')).map((c) => c.getAttribute('data-entry-path'));
 		assert.strictEqual(cardPaths[0], 'Task 1.md', 'First card should snap back to sorted data order');
 		assert.strictEqual(cardPaths[1], 'Task 2.md', 'Second card should snap back to sorted data order');
+	});
+
+	test('Cross-column drop while Base sort is active does not show manual-order notice', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const columns = view.containerEl.querySelectorAll('.obk-column');
+		const toDoColumn = Array.from(columns).find(
+			(col) => col.getAttribute('data-column-value') === 'To Do',
+		) as HTMLElement;
+		const doingColumn = Array.from(columns).find(
+			(col) => col.getAttribute('data-column-value') === 'Doing',
+		) as HTMLElement;
+		const toDoBody = toDoColumn.querySelector('.obk-column-body') as HTMLElement;
+		const doingBody = doingColumn.querySelector('.obk-column-body') as HTMLElement;
+
+		const card = toDoBody.querySelector('.obk-card') as HTMLElement;
+		doingBody.appendChild(card);
+
+		const noticeStart = noticeMessages().length;
+		const mockEvent = { item: card, from: toDoBody, to: doingBody, oldIndex: 0, newIndex: 0 };
+		await (view as any).handleCardDrop(mockEvent);
+
+		assert.deepStrictEqual(noticeMessages().slice(noticeStart), []);
+	});
+
+	test('Same-column unchanged drop while Base sort is active does not show manual-order notice', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const toDoColumn = Array.from(view.containerEl.querySelectorAll('.obk-column')).find(
+			(col) => col.getAttribute('data-column-value') === 'To Do',
+		) as HTMLElement;
+		const toDoBody = toDoColumn.querySelector('.obk-column-body') as HTMLElement;
+		const card = toDoBody.querySelector('.obk-card') as HTMLElement;
+
+		const noticeStart = noticeMessages().length;
+		const mockEvent = { item: card, from: toDoBody, to: toDoBody, oldIndex: 0, newIndex: 0 };
+		await (view as any).handleCardDrop(mockEvent);
+
+		assert.deepStrictEqual(noticeMessages().slice(noticeStart), []);
+	});
+
+	test('Same-column unchanged draggable index while Base sort is active does not show manual-order notice', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const toDoColumn = Array.from(view.containerEl.querySelectorAll('.obk-column')).find(
+			(col) => col.getAttribute('data-column-value') === 'To Do',
+		) as HTMLElement;
+		const toDoBody = toDoColumn.querySelector('.obk-column-body') as HTMLElement;
+		const card = toDoBody.querySelector('.obk-card') as HTMLElement;
+
+		const noticeStart = noticeMessages().length;
+		const mockEvent = {
+			item: card,
+			from: toDoBody,
+			to: toDoBody,
+			oldIndex: 0,
+			newIndex: 1,
+			oldDraggableIndex: 0,
+			newDraggableIndex: 0,
+		};
+		await (view as any).handleCardDrop(mockEvent);
+
+		assert.deepStrictEqual(noticeMessages().slice(noticeStart), []);
 	});
 
 	test('Same-column drop does not call processFrontMatter', async () => {


### PR DESCRIPTION
## Summary
- Keep card Sortable same-column movement enabled so reorder attempts report real index changes
- Show an Obsidian Notice only when a sorted board rejects an actual same-column reorder
- Keep cross-column drag/drop working without warning
- Re-render sorted same-column drops back to Base sort order without persisting manual card order

Addresses #49.

**Demo**:

https://github.com/user-attachments/assets/1efff22a-59ff-401f-9f41-65bfbfef91cd



## Testing
- npm test
- npm run typecheck
- npm run format:check
- npm run lint
- npm run build
- Live Obsidian smoke test for no-op drag vs reorder attempt