### PR TITLE
Fix quick add folder placement

### DIFF
--- a/src/components/quickAdd.ts
+++ b/src/components/quickAdd.ts
@@ -1,4 +1,4 @@
-import type { App, BasesPropertyId } from 'obsidian';
+import type { App, BasesPropertyId, EventRef, TFile } from 'obsidian';
 import { Notice, normalizePath, parsePropertyId, setIcon } from 'obsidian';
 import { QuickAddModal } from '../quickAddModal.ts';
 import { CSS_CLASSES, UNCATEGORIZED_LABEL } from '../constants.ts';
@@ -15,6 +15,9 @@ export interface QuickAddCallbacks {
 	createFileForView: (path: string, setFrontmatter: (fm: Record<string, unknown>) => void) => Promise<void>;
 }
 
+const CREATED_CARD_TIMEOUT_MS = 2000;
+const CREATED_CARD_SETTLE_MS = 50;
+
 function sanitizeBaseFileName(title: string): string {
 	return title
 		.trim()
@@ -30,6 +33,96 @@ function getWritableFrontmatterPropertyName(propertyId: BasesPropertyId | null):
 	const parsed = parsePropertyId(propertyId);
 	if (parsed.type !== 'note') return null;
 	return parsed.name || null;
+}
+
+function getCreatedMarkdownFile(app: App, previousPaths: Set<string>, baseFileName: string): TFile | null {
+	const createdFiles = app.vault.getMarkdownFiles().filter((file) => !previousPaths.has(file.path));
+	if (createdFiles.length === 0) return null;
+
+	const preferredBasename = baseFileName.split('/').pop() ?? baseFileName;
+	return createdFiles.find((file) => file.basename === preferredBasename) ?? createdFiles[0] ?? null;
+}
+
+function getParentPath(path: string): string {
+	const normalizedPath = normalizePath(path);
+	const separatorIndex = normalizedPath.lastIndexOf('/');
+	return separatorIndex === -1 ? '' : normalizedPath.slice(0, separatorIndex);
+}
+
+function isFileInFolder(file: TFile, folder: string): boolean {
+	return getParentPath(file.path) === normalizePath(folder);
+}
+
+function waitForCreatedMarkdownFile(app: App, previousPaths: Set<string>, baseFileName: string): Promise<TFile | null> {
+	if (typeof app.vault.on !== 'function' || typeof app.vault.offref !== 'function') {
+		return Promise.resolve(null);
+	}
+
+	return new Promise((resolve) => {
+		let eventRef: EventRef | null = null;
+		let timeoutId: number | null = null;
+		let settled = false;
+
+		const cleanup = () => {
+			if (timeoutId !== null) window.clearTimeout(timeoutId);
+			if (eventRef) app.vault.offref(eventRef);
+		};
+
+		const finish = (file: TFile | null) => {
+			if (settled) return;
+			settled = true;
+			cleanup();
+			resolve(file);
+		};
+
+		const finishIfCreated = () => {
+			const createdFile = getCreatedMarkdownFile(app, previousPaths, baseFileName);
+			if (createdFile) finish(createdFile);
+		};
+
+		eventRef = app.vault.on('create', () => {
+			finishIfCreated();
+			window.setTimeout(finishIfCreated, CREATED_CARD_SETTLE_MS);
+		});
+		timeoutId = window.setTimeout(() => {
+			finish(getCreatedMarkdownFile(app, previousPaths, baseFileName));
+		}, CREATED_CARD_TIMEOUT_MS);
+	});
+}
+
+function getAvailablePath(app: App, folder: string, fileName: string): string {
+	const extension = fileName.toLowerCase().endsWith('.md') ? '.md' : '';
+	const basename = extension ? fileName.slice(0, -extension.length) : fileName;
+	let candidate = normalizePath(`${folder}/${extension ? fileName : `${fileName}.md`}`);
+	let counter = 1;
+
+	while (app.vault.getAbstractFileByPath(candidate)) {
+		candidate = normalizePath(`${folder}/${basename} ${counter}.md`);
+		counter++;
+	}
+
+	return candidate;
+}
+
+async function ensureCreatedCardInFolder(
+	app: App,
+	previousPaths: Set<string>,
+	createdFilePromise: Promise<TFile | null>,
+	baseFileName: string,
+	folder: string,
+): Promise<void> {
+	const createdFile = getCreatedMarkdownFile(app, previousPaths, baseFileName) ?? (await createdFilePromise);
+	if (!createdFile) {
+		new Notice(`Created card, but could not move it to ${folder}.`);
+		return;
+	}
+
+	if (isFileInFolder(createdFile, folder)) return;
+
+	const targetPath = getAvailablePath(app, folder, baseFileName);
+	if (targetPath === createdFile.path) return;
+
+	await app.fileManager.renameFile(createdFile, targetPath);
 }
 
 export function closeNativeNewItemPopover(doc: Document): void {
@@ -84,8 +177,9 @@ export async function createQuickAddCard(
 		new Notice(`Quick add folder not found: ${targetFolder}`);
 		return;
 	}
-
 	const fileNameToCreate = normalizePath(`${targetFolder}/${baseFileName}`);
+	const createdFilePaths = new Set(ctx.app.vault.getMarkdownFiles().map((file) => file.path));
+	const createdFilePromise = waitForCreatedMarkdownFile(ctx.app, createdFilePaths, fileNameToCreate);
 
 	const setFrontmatter = (frontmatter: Record<string, unknown>): void => {
 		if (columnValue === UNCATEGORIZED_LABEL) {
@@ -105,6 +199,7 @@ export async function createQuickAddCard(
 	try {
 		await cb.createFileForView(fileNameToCreate, setFrontmatter);
 		closeNativeNewItemPopover(ctx.doc);
+		await ensureCreatedCardInFolder(ctx.app, createdFilePaths, createdFilePromise, baseFileName, targetFolder);
 	} catch (error) {
 		console.error('Error creating kanban card:', error);
 		new Notice('Could not create card.');

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -416,19 +416,32 @@ describe('Data Rendering - Column Rendering', () => {
 		]);
 	});
 
-	test('quick add creates file directly in the configured folder', async () => {
+	test('quick add does not move when Bases creates directly in the configured folder', async () => {
 		const entries = createEntriesWithStatus();
+		const createdFile = createMockTFile('energy/New Task.md');
+		let markdownFiles = [createMockTFile('dashboards/maintenance-board.base')];
 
 		controller = createMockQueryController(entries, TEST_PROPERTIES);
 		controller.app = app;
 		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
 		controller.config.set('quickAddFolder', 'energy');
 
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
 		(app.vault as any).getFolderByPath = (path: string) => (path === 'energy' ? { path, name: 'energy' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
 
 		const view = new KanbanView(controller, scrollEl);
 		setupKanbanViewWithApp(view, app);
 		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			markdownFiles = [...markdownFiles, createdFile];
+		};
 
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
@@ -436,6 +449,156 @@ describe('Data Rendering - Column Rendering', () => {
 			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
 		]);
 		assert.deepStrictEqual(app.fileManager.renameFile.calls, []);
+	});
+
+	test('quick add moves the created file when Bases ignores the configured folder', async () => {
+		const entries = createEntriesWithStatus();
+		const createdFile = createMockTFile('dashboards/New Task.md');
+		let markdownFiles = [createMockTFile('dashboards/maintenance-board.base')];
+
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'energy');
+
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
+		(app.vault as any).getFolderByPath = (path: string) => (path === 'energy' ? { path, name: 'energy' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			markdownFiles = [...markdownFiles, createdFile];
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+		]);
+		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
+	});
+
+	test('quick add moves wrong-folder suffixed files to the requested target name when it is free', async () => {
+		const entries = createEntriesWithStatus();
+		const createdFile = createMockTFile('dashboards/New Task 1.md');
+		let markdownFiles = [createMockTFile('dashboards/maintenance-board.base')];
+
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'energy');
+
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
+		(app.vault as any).getFolderByPath = (path: string) => (path === 'energy' ? { path, name: 'energy' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			markdownFiles = [...markdownFiles, createdFile];
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+		]);
+		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
+	});
+
+	test('quick add picks the next target filename when the configured folder already has a collision', async () => {
+		const entries = createEntriesWithStatus();
+		const existingTarget = createMockTFile('energy/New Task.md');
+		const createdFile = createMockTFile('dashboards/New Task.md');
+		let markdownFiles = [createMockTFile('dashboards/maintenance-board.base'), existingTarget];
+
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'energy');
+
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
+		(app.vault as any).getFolderByPath = (path: string) => (path === 'energy' ? { path, name: 'energy' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			markdownFiles = [...markdownFiles, createdFile];
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+		]);
+		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task 1.md']);
+	});
+
+	test('quick add waits for async Bases file creation before moving the card', async () => {
+		const entries = createEntriesWithStatus();
+		const createdFile = createMockTFile('dashboards/New Task.md');
+		let markdownFiles = [createMockTFile('dashboards/maintenance-board.base')];
+		let createHandler: (() => void) | null = null;
+
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'energy');
+
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
+		(app.vault as any).getFolderByPath = (path: string) => (path === 'energy' ? { path, name: 'energy' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
+		(app.vault as any).on = (name: string, handler: () => void) => {
+			if (name === 'create') createHandler = handler;
+			return { name };
+		};
+		(app.vault as any).offref = () => {};
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			window.setTimeout(() => {
+				markdownFiles = [...markdownFiles, createdFile];
+				createHandler?.();
+			}, 10);
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [
+			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+		]);
+		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
 	});
 
 	test('quick add closes the native Base new item popover', async () => {


### PR DESCRIPTION
## Summary

Fixes quick add folder placement when Obsidian/Bases ignores the folder portion passed to `createFileForView`.

This keeps the current direct creation path from #66 first, then verifies where the file actually landed. If Bases already creates the note in the configured `quickAddFolder`, nothing else happens. If the note is created elsewhere, the plugin moves it into the configured folder as a fallback.

## Rationale

Refs #78 and the discussion here: https://github.com/xiwcx/obsidian-bases-kanban/issues/78#issuecomment-4530458587

`createFileForView("folder/title", ...)` appears to be environment-dependent. In some setups it behaves like a path-aware create; in others it creates beside the base file or in the vault root. The fallback avoids assuming either behavior is universal.

The implementation still lets Bases create the note so Base-derived frontmatter and filter-derived properties are preserved, then only corrects the location if the observed result is outside the configured folder.

## Details

- Snapshot markdown paths before quick add.
- Call `createFileForView(normalizePath(`${targetFolder}/${baseFileName}`), setFrontmatter)` first.
- Detect the created markdown file, including async creation via the vault `create` event.
- Skip renaming when the created file is already in `quickAddFolder`.
- Move the created file into `quickAddFolder` only when needed.
- Use the requested card title for fallback destination naming, so a wrong-folder suffix like `New Task 1.md` can still become `target/New Task.md` if that target is free.
- Preserve collision handling in the configured folder.

## Testing

- `npm test -- --run tests/kanbanView.test.ts` (217 passing)
- `npm run build`
- `npm run format:check`
- Live Obsidian probe against a configured `quickAddFolder`, confirming the created note lands in the target folder and keeps Base-derived frontmatter

Noted: `npm run lint` currently fails before linting changed files due to the existing ESLint config load error: `obsidianmd.configs.recommended.map is not a function`.
