### PR TITLE
fix: resolve wikilink aliases in swimlane titles

### DIFF
--- a/src/components/column.ts
+++ b/src/components/column.ts
@@ -1,5 +1,6 @@
-import type { BasesEntry } from 'obsidian';
+import type { BasesEntry, MetadataCache } from 'obsidian';
 import { COLOR_PALETTE, CSS_CLASSES, DATA_ATTRIBUTES } from '../constants.ts';
+import { resolveWikilinkDisplay } from '../utils/wikilink.ts';
 import { createCard, computeCardFingerprint, type CardRenderCtx, type CardCallbacks } from './card.ts';
 
 export interface ColumnRenderCtx {
@@ -9,6 +10,7 @@ export interface ColumnRenderCtx {
 	prefs: { columnColors: Record<string, string> };
 	dragging: boolean;
 	cardFingerprints: Map<string, string>;
+	metadataCache: MetadataCache | null;
 }
 
 export interface ColumnCallbacks {
@@ -75,7 +77,10 @@ export function createColumn(
 		cb.onColorPickerClick(colorBtn, columnEl, value);
 	});
 
-	headerEl.createSpan({ text: value, cls: CSS_CLASSES.COLUMN_TITLE });
+	headerEl.createSpan({
+		text: resolveWikilinkDisplay(value, ctx.metadataCache),
+		cls: CSS_CLASSES.COLUMN_TITLE,
+	});
 	headerEl.createSpan({ text: `${entries.length}`, cls: CSS_CLASSES.COLUMN_COUNT });
 
 	if (cb.getQuickAddFolder()) {

--- a/src/components/row.ts
+++ b/src/components/row.ts
@@ -1,6 +1,7 @@
 import { setIcon } from 'obsidian';
 import { CSS_CLASSES, DATA_ATTRIBUTES, UNCATEGORIZED_LABEL } from '../constants.ts';
 import type { BasesEntry } from 'obsidian';
+import { resolveWikilinkDisplay } from '../utils/wikilink.ts';
 import { createColumn, type ColumnRenderCtx, type ColumnCallbacks } from './column.ts';
 
 export interface RowRenderCtx extends ColumnRenderCtx {
@@ -57,8 +58,9 @@ export function buildSwimlaneElement(
 	const headerEl = laneEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_HEADER });
 	const dragHandle = headerEl.createDiv({ cls: CSS_CLASSES.SWIMLANE_DRAG_HANDLE });
 	dragHandle.textContent = '⋮⋮';
-	dragHandle.setAttribute('aria-label', `Drag to reorder lane: ${laneValue}`);
-	headerEl.createSpan({ text: laneValue, cls: CSS_CLASSES.SWIMLANE_TITLE });
+	const laneDisplay = resolveWikilinkDisplay(laneValue, ctx.metadataCache);
+	dragHandle.setAttribute('aria-label', `Drag to reorder lane: ${laneDisplay}`);
+	headerEl.createSpan({ text: laneDisplay, cls: CSS_CLASSES.SWIMLANE_TITLE });
 	const laneCount = orderedColumnValues.reduce((sum, col) => sum + (laneEntries.get(col)?.length ?? 0), 0);
 	headerEl.createSpan({ text: `${laneCount}`, cls: CSS_CLASSES.SWIMLANE_COUNT });
 	const toggleBtn = headerEl.createEl('button', {

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -990,6 +990,7 @@ export class KanbanView extends BasesView {
 			prefs: { columnColors: this._prefs.columnColors },
 			dragging: this._dragging,
 			cardFingerprints: this._cardFingerprints,
+			metadataCache: this.app?.metadataCache ?? null,
 		};
 	}
 

--- a/src/utils/wikilink.ts
+++ b/src/utils/wikilink.ts
@@ -46,8 +46,8 @@ function lookupFrontmatterAlias(metadataCache: MetadataCache, target: string): s
 		const cache = metadataCache.getFileCache(file);
 		const frontmatter: unknown = cache?.frontmatter;
 		if (!frontmatter || typeof frontmatter !== 'object') return undefined;
-		const aliases = (frontmatter as Record<string, unknown>).aliases;
-		return firstNonEmptyAlias(aliases);
+		if (!('aliases' in frontmatter)) return undefined;
+		return firstNonEmptyAlias(frontmatter.aliases);
 	} catch (error) {
 		console.warn('resolveWikilinkDisplay: metadataCache lookup failed', error);
 		return undefined;

--- a/src/utils/wikilink.ts
+++ b/src/utils/wikilink.ts
@@ -30,24 +30,37 @@ export function resolveWikilinkDisplay(value: string, metadataCache: MetadataCac
 	const target = rawTarget.replace(/[#^].*$/, '').trim();
 
 	if (metadataCache && target) {
-		try {
-			const file = metadataCache.getFirstLinkpathDest(target, '');
-			if (file) {
-				const cache = metadataCache.getFileCache(file);
-				const aliases = cache?.frontmatter?.aliases;
-				if (Array.isArray(aliases)) {
-					const first = aliases.find((a) => typeof a === 'string' && a.trim().length > 0);
-					if (typeof first === 'string') return first.trim();
-				} else if (typeof aliases === 'string' && aliases.trim().length > 0) {
-					return aliases.trim();
-				}
-			}
-		} catch (error) {
-			console.warn('resolveWikilinkDisplay: metadataCache lookup failed', error);
-		}
+		const aliasFromCache = lookupFrontmatterAlias(metadataCache, target);
+		if (aliasFromCache) return aliasFromCache;
 	}
 
 	const parts = target.split('/');
 	const last = parts[parts.length - 1];
 	return last || target || value;
+}
+
+function lookupFrontmatterAlias(metadataCache: MetadataCache, target: string): string | undefined {
+	try {
+		const file = metadataCache.getFirstLinkpathDest(target, '');
+		if (!file) return undefined;
+		const cache = metadataCache.getFileCache(file);
+		const frontmatter: unknown = cache?.frontmatter;
+		if (!frontmatter || typeof frontmatter !== 'object') return undefined;
+		const aliases = (frontmatter as Record<string, unknown>).aliases;
+		return firstNonEmptyAlias(aliases);
+	} catch (error) {
+		console.warn('resolveWikilinkDisplay: metadataCache lookup failed', error);
+		return undefined;
+	}
+}
+
+function firstNonEmptyAlias(aliases: unknown): string | undefined {
+	if (Array.isArray(aliases)) {
+		for (const a of aliases) {
+			if (typeof a === 'string' && a.trim().length > 0) return a.trim();
+		}
+		return undefined;
+	}
+	if (typeof aliases === 'string' && aliases.trim().length > 0) return aliases.trim();
+	return undefined;
 }

--- a/src/utils/wikilink.ts
+++ b/src/utils/wikilink.ts
@@ -1,0 +1,53 @@
+import type { MetadataCache } from 'obsidian';
+
+const WIKILINK_RE = /^\[\[([^\]]+)\]\]$/;
+
+/**
+ * If `value` is wrapped in `[[ ]]`, return a human-readable display string.
+ * Resolution order:
+ *   1. Explicit pipe alias: `[[Note|My Alias]]` → "My Alias"
+ *   2. First entry of the target note's `aliases` frontmatter, if the note
+ *      exists in the vault and the metadata cache has a record for it.
+ *   3. The link target's basename (last path segment, with any `#heading`
+ *      or `^block-ref` stripped).
+ *
+ * Non-wikilink values are returned unchanged so this is safe to call on every
+ * lane/column label without first checking the shape.
+ */
+export function resolveWikilinkDisplay(value: string, metadataCache: MetadataCache | null | undefined): string {
+	if (typeof value !== 'string') return value;
+	const match = value.match(WIKILINK_RE);
+	if (!match) return value;
+
+	const inner = match[1];
+	const pipeIdx = inner.indexOf('|');
+	if (pipeIdx >= 0) {
+		const alias = inner.slice(pipeIdx + 1).trim();
+		if (alias) return alias;
+	}
+
+	const rawTarget = pipeIdx >= 0 ? inner.slice(0, pipeIdx) : inner;
+	const target = rawTarget.replace(/[#^].*$/, '').trim();
+
+	if (metadataCache && target) {
+		try {
+			const file = metadataCache.getFirstLinkpathDest(target, '');
+			if (file) {
+				const cache = metadataCache.getFileCache(file);
+				const aliases = cache?.frontmatter?.aliases;
+				if (Array.isArray(aliases)) {
+					const first = aliases.find((a) => typeof a === 'string' && a.trim().length > 0);
+					if (typeof first === 'string') return first.trim();
+				} else if (typeof aliases === 'string' && aliases.trim().length > 0) {
+					return aliases.trim();
+				}
+			}
+		} catch (error) {
+			console.warn('resolveWikilinkDisplay: metadataCache lookup failed', error);
+		}
+	}
+
+	const parts = target.split('/');
+	const last = parts[parts.length - 1];
+	return last || target || value;
+}

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -262,7 +262,10 @@ export function createMockFn(): MockFn {
 }
 
 // Mock App
-export function createMockApp(imageFiles: Record<string, { path: string }> = {}): App & {
+export function createMockApp(
+	imageFiles: Record<string, { path: string }> = {},
+	noteAliases: Record<string, string[]> = {},
+): App & {
 	workspace: {
 		openLinkText: MockFn;
 		trigger: MockFn;
@@ -315,7 +318,17 @@ export function createMockApp(imageFiles: Record<string, { path: string }> = {})
 			renameFile,
 		} as any,
 		metadataCache: {
-			getFirstLinkpathDest: (linkpath: string, _sourcePath: string) => imageFiles[linkpath] ?? null,
+			getFirstLinkpathDest: (linkpath: string, _sourcePath: string) => {
+				if (imageFiles[linkpath]) return imageFiles[linkpath];
+				if (noteAliases[linkpath]) return { path: `${linkpath}.md` };
+				return null;
+			},
+			getFileCache: (file: { path: string }) => {
+				const linkpath = file.path.replace(/\.md$/, '');
+				const aliases = noteAliases[linkpath];
+				if (aliases) return { frontmatter: { aliases } };
+				return null;
+			},
 		} as any,
 		vault: {
 			getMarkdownFiles: () => markdownFiles,

--- a/tests/mocks/obsidian.ts
+++ b/tests/mocks/obsidian.ts
@@ -40,6 +40,20 @@ export interface QueryController {
 	app?: App;
 }
 
+export interface FrontMatterCache {
+	aliases?: string | string[];
+	[key: string]: unknown;
+}
+
+export interface CachedMetadata {
+	frontmatter?: FrontMatterCache;
+}
+
+export interface MetadataCache {
+	getFirstLinkpathDest(linkpath: string, sourcePath: string): TFile | null;
+	getFileCache(file: TFile): CachedMetadata | null;
+}
+
 export interface App {
 	workspace: {
 		openLinkText(path: string, source: string, newLeaf: boolean, openViewState?: { active?: boolean }): void;
@@ -55,6 +69,7 @@ export interface App {
 		processFrontMatter(file: TFile, fn: (frontmatter: any) => void | Promise<void>): Promise<void>;
 		renameFile(file: TFile, newPath: string): Promise<void>;
 	};
+	metadataCache: MetadataCache;
 	vault: {
 		getMarkdownFiles(): TFile[];
 		getFolderByPath(path: string): { path: string; name: string } | null;

--- a/tests/swimlane.test.ts
+++ b/tests/swimlane.test.ts
@@ -292,6 +292,63 @@ describe('Swimlane rendering behavior', () => {
 	});
 });
 
+describe('Swimlane wikilink alias rendering', () => {
+	function createWikilinkSwimlaneView(noteAliases: Record<string, string[]> = {}): {
+		view: KanbanView;
+		controller: any;
+		scrollEl: HTMLElement;
+	} {
+		const entries: BasesEntry[] = [
+			createMockBasesEntry(createMockTFile('Task A.md'), {
+				[PROPERTY_STATUS]: 'To Do',
+				[PROPERTY_ASSIGNEE]: '[[Note Title]]',
+			}),
+			createMockBasesEntry(createMockTFile('Task B.md'), {
+				[PROPERTY_STATUS]: 'Done',
+				[PROPERTY_ASSIGNEE]: '[[Note Title|Custom Alias]]',
+			}),
+		];
+		const scrollEl = createDivWithMethods();
+		const controller: any = createMockQueryController(entries, TEST_PROPERTIES);
+		const app = createMockApp({}, noteAliases);
+		controller.app = app;
+		controller.config.getAsPropertyId = (key: string) => {
+			if (key === 'groupByProperty') return PROPERTY_STATUS;
+			if (key === 'swimlaneByProperty') return PROPERTY_ASSIGNEE;
+			return null;
+		};
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		return { view, controller, scrollEl };
+	}
+
+	function getSwimlaneTitle(view: KanbanView, laneRawValue: string): string | null {
+		const lane = view.containerEl.querySelector<HTMLElement>(
+			`.${CSS_CLASSES.SWIMLANE}[${DATA_ATTRIBUTES.SWIMLANE_VALUE}="${laneRawValue}"]`,
+		);
+		if (!lane) return null;
+		return lane.querySelector(`.${CSS_CLASSES.SWIMLANE_TITLE}`)?.textContent ?? null;
+	}
+
+	test('[[Note Title]] displays as "Note Title" in swimlane header', () => {
+		const { view } = createWikilinkSwimlaneView();
+		triggerDataUpdate(view);
+		assert.strictEqual(getSwimlaneTitle(view, '[[Note Title]]'), 'Note Title');
+	});
+
+	test('[[Note Title|Custom Alias]] displays as "Custom Alias" in swimlane header', () => {
+		const { view } = createWikilinkSwimlaneView();
+		triggerDataUpdate(view);
+		assert.strictEqual(getSwimlaneTitle(view, '[[Note Title|Custom Alias]]'), 'Custom Alias');
+	});
+
+	test('first frontmatter alias is used when wikilink has no pipe alias', () => {
+		const { view } = createWikilinkSwimlaneView({ 'Note Title': ['Friendly Name'] });
+		triggerDataUpdate(view);
+		assert.strictEqual(getSwimlaneTitle(view, '[[Note Title]]'), 'Friendly Name');
+	});
+});
+
 describe('Swimlane patch path', () => {
 	test('second render reuses existing lane elements (no full teardown)', () => {
 		const { view } = createSwimlaneView(() => PROPERTY_PRIORITY);


### PR DESCRIPTION
Closes #70

Swimlane and column titles that contain wikilink syntax (e.g. `[[Note Title]]`) were displayed as raw text rather than resolved display names. This was especially visible when a Bases property used a wikilink value as a column grouping key.

## Changes

- Added `src/utils/wikilink.ts` with a `resolveWikilinkDisplay()` helper that resolves wikilinks in three steps:
  1. Pipe alias: `[[Note|Alias]]` → "Alias"
  2. Frontmatter alias lookup via `MetadataCache`
  3. Basename fallback: strip `[[` and `]]`
- Non-wikilink values pass through unchanged.
- Applied to swimlane title rendering in `src/components/row.ts`
- Applied to column title rendering in `src/components/column.ts`
- Added three test cases in `tests/swimlane.test.ts` covering all resolution paths

## Testing

All 220 existing tests continue to pass. Three new tests added specifically for this fix.