### PR TITLE
Fix card order reconciliation - Fix Issue #94

### DIFF
--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -402,6 +402,10 @@ export class KanbanView extends BasesView {
 				: this.groupEntriesByProperty(entries, this.groupByPropertyId);
 			const sortActive = this.hasActiveSort();
 
+			if (!sortActive) {
+				this.reconcileCardOrdersFromEntries(groupedByLane, groupedEntries);
+			}
+
 			// Apply manual card order only when the Base itself is not sorted.
 			// When sorting is active, Bases has already ordered `entries`.
 			if (!sortActive && groupedByLane) {
@@ -507,6 +511,47 @@ export class KanbanView extends BasesView {
 			this.reapplyActiveCard();
 		} catch (error) {
 			console.error('KanbanView error:', error);
+		}
+	}
+
+	private reconcileCardOrdersFromEntries(
+		groupedByLane: Map<string, Map<string, BasesEntry[]>> | null,
+		groupedEntries: Map<string, BasesEntry[]>,
+	): void {
+		if (Object.keys(this._prefs.cardOrders).length === 0) return;
+
+		const keepSavedOrder = (entries: BasesEntry[], savedOrder: string[] = []): string[] => {
+			const livePaths = entries.map((entry) => entry.file.path);
+			const liveSet = new Set(livePaths);
+			const ordered = savedOrder.filter((path) => liveSet.has(path));
+			const orderedSet = new Set(ordered);
+
+			return [...ordered, ...livePaths.filter((path) => !orderedSet.has(path))];
+		};
+
+		const nextCardOrders: Record<string, string[]> = {};
+
+		if (groupedByLane) {
+			groupedByLane.forEach((columns, laneValue) => {
+				const columnValues = new Set([...this._prefs.columnOrder, ...columns.keys()]);
+
+				columnValues.forEach((columnValue) => {
+					const key = this.cardOrderKey(laneValue, columnValue);
+					nextCardOrders[key] = keepSavedOrder(columns.get(columnValue) ?? [], this._prefs.cardOrders[key]);
+				});
+			});
+		} else {
+			const columnValues = new Set([...this._prefs.columnOrder, ...groupedEntries.keys()]);
+
+			columnValues.forEach((columnValue) => {
+				const key = this.cardOrderKey(null, columnValue);
+				nextCardOrders[key] = keepSavedOrder(groupedEntries.get(columnValue) ?? [], this._prefs.cardOrders[key]);
+			});
+		}
+
+		if (JSON.stringify(this._prefs.cardOrders) !== JSON.stringify(nextCardOrders)) {
+			this._prefs.cardOrders = nextCardOrders;
+			this._persistPrefs();
 		}
 	}
 

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -51,6 +51,7 @@ import {
 	setupTestEnvironment,
 	triggerDataUpdate,
 } from './helpers.ts';
+import { StringValue } from './mocks/obsidian.ts';
 
 setupTestEnvironment();
 
@@ -3141,6 +3142,66 @@ describe('Card Order - Persistence', () => {
 		// Should preserve dragged order, not revert to original Bases order
 		assert.strictEqual(reRenderedPaths[0], originalSecond, 'Dragged card should remain first after re-render');
 		assert.strictEqual(reRenderedPaths[1], originalFirst, 'Original first card should remain second after re-render');
+	});
+
+	test('Re-render reconciles card order when entry status changes outside drag-drop', () => {
+		const statuses: Record<string, string> = {
+			'Task 1.md': 'To Do',
+			'Task 2.md': 'To Do',
+			'Task 3.md': 'Doing',
+		};
+		const entries = Object.keys(statuses).map((path) => {
+			const entry = createMockBasesEntry(createMockTFile(path), { [PROPERTY_STATUS]: statuses[path] });
+			(entry as any).getValue = (propId: string) => {
+				if (propId === PROPERTY_STATUS) return new StringValue(statuses[path]);
+				return null;
+			};
+			return entry;
+		});
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('cardOrders', {
+			[PROPERTY_STATUS]: {
+				'To Do': ['Task 2.md', 'Task 1.md'],
+				Doing: ['Ghost.md', 'Task 3.md'],
+			},
+		});
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		statuses['Task 1.md'] = 'Doing';
+		triggerDataUpdate(view);
+
+		const savedOrders = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(savedOrders[PROPERTY_STATUS]['To Do'], ['Task 2.md']);
+		assert.deepStrictEqual(savedOrders[PROPERTY_STATUS].Doing, ['Task 3.md', 'Task 1.md']);
+	});
+
+	test('Re-render does not reconcile card order while Base sort is active', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+		controller.config.set('cardOrders', {
+			[PROPERTY_STATUS]: {
+				'To Do': ['Ghost.md', 'Task 2.md'],
+			},
+		});
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const savedOrders = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(
+			savedOrders[PROPERTY_STATUS]['To Do'],
+			['Ghost.md', 'Task 2.md'],
+			'Sorted Bases should not rewrite manual cardOrders during render',
+		);
 	});
 });
 

--- a/tests/swimlane.test.ts
+++ b/tests/swimlane.test.ts
@@ -13,6 +13,7 @@ import {
 	setupTestEnvironment,
 	triggerDataUpdate,
 } from './helpers.ts';
+import { StringValue } from './mocks/obsidian.ts';
 
 setupTestEnvironment();
 
@@ -289,6 +290,59 @@ describe('Swimlane rendering behavior', () => {
 			'Swimlane card order should not leak into flat card order',
 		);
 		assert.deepStrictEqual(savedOrders[scopedKey][`High${SWIMLANE_KEY_SEPARATOR}To Do`], ['Task B.md', 'Task A.md']);
+	});
+
+	test('swimlane card order is reconciled when an entry changes lane outside drag-drop', () => {
+		const priorities: Record<string, string> = {
+			'Task A.md': 'High',
+			'Task B.md': 'High',
+			'Task C.md': 'Low',
+		};
+		const statuses: Record<string, string> = {
+			'Task A.md': 'To Do',
+			'Task B.md': 'To Do',
+			'Task C.md': 'Done',
+		};
+		const entries = Object.keys(priorities).map((path) => {
+			const entry = createMockBasesEntry(createMockTFile(path), {
+				[PROPERTY_STATUS]: statuses[path],
+				[PROPERTY_PRIORITY]: priorities[path],
+			});
+			(entry as any).getValue = (propId: string) => {
+				if (propId === PROPERTY_STATUS) return new StringValue(statuses[path]);
+				if (propId === PROPERTY_PRIORITY) return new StringValue(priorities[path]);
+				return null;
+			};
+			return entry;
+		});
+		const controller: any = createMockQueryController(entries, TEST_PROPERTIES);
+		const app = createMockApp();
+		controller.app = app;
+		controller.config.getAsPropertyId = (key: string) => {
+			if (key === 'groupByProperty') return PROPERTY_STATUS;
+			if (key === 'swimlaneByProperty') return PROPERTY_PRIORITY;
+			return null;
+		};
+		const scopedKey = `${PROPERTY_STATUS}${SWIMLANE_KEY_SEPARATOR}${PROPERTY_PRIORITY}`;
+		controller.config.set('cardOrders', {
+			[scopedKey]: {
+				[`High${SWIMLANE_KEY_SEPARATOR}To Do`]: ['Task B.md', 'Task A.md'],
+				[`Low${SWIMLANE_KEY_SEPARATOR}To Do`]: ['Ghost.md'],
+			},
+		});
+
+		const scrollEl = createDivWithMethods();
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		priorities['Task B.md'] = 'Low';
+		triggerDataUpdate(view);
+
+		const savedOrders = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(savedOrders[scopedKey][`High${SWIMLANE_KEY_SEPARATOR}To Do`], ['Task A.md']);
+		assert.deepStrictEqual(savedOrders[scopedKey][`Low${SWIMLANE_KEY_SEPARATOR}To Do`], ['Task B.md']);
+		assert.strictEqual(savedOrders[PROPERTY_STATUS], undefined, 'Swimlane reconciliation should not write flat order');
 	});
 });
 


### PR DESCRIPTION
## Summary

  Fixes manual card order reconciliation when a card changes its grouped property
  outside drag-and-drop.

  Previously, if a note's frontmatter status changed directly, the saved
  `cardOrders` in the `.base` file could keep the card under the old column. This
  made the persisted order stale until another manual drag happened.

  This change reconciles saved card orders during render when Base sorting is not
  active, removing stale paths from old columns and appending moved cards to their
  current column.

  ## Verification

  - Changed a card frontmatter status from `Question` to `Test`.
  - Confirmed the `.base` file moved the card path from
  `cardOrders.note.status.Question` to `cardOrders.note.status.Test`.
  - Confirmed the card path was not duplicated across columns.
  - Added tests for flat kanban and swimlane reconciliation.
  - Confirmed reconciliation is skipped when Base sort is active.