### PR TITLE
fix: persist card order on every drag, and drop stale cardOrders entries

### DIFF
--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -304,6 +304,14 @@ export class KanbanView extends BasesView {
 	 *
 	 * Change guards skip config.set() when the value hasn't changed, preventing
 	 * spurious onDataUpdated() triggers.
+	 *
+	 * The stored value must be a snapshot, never the live _prefs object. Handing
+	 * _prefs straight to set() aliases it into the config: later mutations of
+	 * _prefs then also mutate the config value in place, so the guard below ends up
+	 * comparing an object with itself, always finds them equal, and never calls
+	 * set() again. Obsidian is never told the Base changed, so nothing is written
+	 * until the view closes and the config is serialised wholesale — which looks
+	 * exactly like "card order only saves on close".
 	 */
 	private _persistConfigKey<T>(
 		key: string,
@@ -315,7 +323,7 @@ export class KanbanView extends BasesView {
 		const raw = this.config?.get(key);
 		const all: Record<string, T> = guard(raw) ? raw : {};
 		if (JSON.stringify(all[storageKey]) !== JSON.stringify(newValue)) {
-			this.config?.set(key, { ...all, [storageKey]: newValue });
+			this.config?.set(key, { ...all, [storageKey]: structuredClone(newValue) });
 		}
 	}
 
@@ -405,6 +413,16 @@ export class KanbanView extends BasesView {
 				? this.flattenLanes(groupedByLane)
 				: this.groupEntriesByProperty(entries, this.groupByPropertyId);
 			const sortActive = this.hasActiveSort();
+
+			// Drop card order entries that the live data proves wrong before they
+			// are applied, so a stale path cannot keep pinning a card's old slot.
+			if (
+				!sortActive &&
+				!this._dragging &&
+				this._pruneCardOrders(this.buildLivePathToKey(groupedByLane, groupedEntries))
+			) {
+				this._persistPrefs();
+			}
 
 			// Apply manual card order only when the Base itself is not sorted.
 			// When sorting is active, Bases has already ordered `entries`.
@@ -1455,6 +1473,65 @@ export class KanbanView extends BasesView {
 		// Include all saved columns (even empty ones); append any new live values.
 		const newValues = liveValues.filter((v) => !this._prefs.columnOrder.includes(v));
 		return [...this._prefs.columnOrder, ...newValues];
+	}
+
+	/**
+	 * Map every entry in the current dataset to the cardOrders key of the cell it
+	 * actually occupies right now.
+	 */
+	private buildLivePathToKey(
+		groupedByLane: Map<string, Map<string, BasesEntry[]>> | null,
+		groupedEntries: Map<string, BasesEntry[]>,
+	): Map<string, string> {
+		const livePathToKey = new Map<string, string>();
+		if (groupedByLane) {
+			groupedByLane.forEach((columns, laneValue) => {
+				columns.forEach((cellEntries, columnValue) => {
+					const key = this.cardOrderKey(laneValue, columnValue);
+					cellEntries.forEach((entry) => livePathToKey.set(entry.file.path, key));
+				});
+			});
+		} else {
+			groupedEntries.forEach((columnEntries, columnValue) => {
+				const key = this.cardOrderKey(null, columnValue);
+				columnEntries.forEach((entry) => livePathToKey.set(entry.file.path, key));
+			});
+		}
+		return livePathToKey;
+	}
+
+	/**
+	 * Remove card order entries that no longer describe where a card lives.
+	 *
+	 * A card's cell is derived from its group-by property, which can change
+	 * without any drag: a script rewrites the frontmatter, another device syncs,
+	 * or the user edits the note directly. handleCardDrop only rewrites the two
+	 * cells it sees, so those paths linger in their old cell's list indefinitely
+	 * and every later drag rewrites the accumulated cruft back into the Base.
+	 *
+	 * Pruning is deliberately conservative — a path is only dropped when the live
+	 * data positively places it somewhere else. A path that is merely absent from
+	 * the dataset is kept, because absence is ambiguous: the card may be hidden by
+	 * the Base's own filters, or the query may not have caught up yet, and its
+	 * manual order has to survive both. Entries for deleted files therefore linger,
+	 * which is harmless — applyCardOrder skips paths it cannot resolve — and is a
+	 * far better failure mode than silently dropping a live card's slot.
+	 *
+	 * @returns true if anything changed and prefs need persisting.
+	 */
+	private _pruneCardOrders(livePathToKey: Map<string, string>): boolean {
+		let changed = false;
+		for (const [key, paths] of Object.entries(this._prefs.cardOrders)) {
+			const kept = paths.filter((path) => {
+				const liveKey = livePathToKey.get(path);
+				return liveKey === undefined || liveKey === key;
+			});
+			if (kept.length !== paths.length) {
+				this._prefs.cardOrders[key] = kept;
+				changed = true;
+			}
+		}
+		return changed;
 	}
 
 	private applyCardOrder(entries: BasesEntry[], savedOrder: string[]): BasesEntry[] {

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -4046,3 +4046,183 @@ describe('patchColumnCards - property value reactivity', () => {
 		assert.strictEqual(countEl?.textContent, '1', 'Column count should remain 1 after a property-only update');
 	});
 });
+
+describe('cardOrders pruning', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let scrollEl: HTMLElement;
+	let controller: any;
+
+	beforeEach(() => {
+		setupTestEnvironment();
+		app = createMockApp();
+		scrollEl = createDivWithMethods();
+	});
+
+	test('Prunes a card order entry whose card now lives in another column', () => {
+		// Task 3 is live in "Doing", but a stale entry still pins it in "To Do" —
+		// the shape left behind when a script rewrites the property without a drag.
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('cardOrders', {
+			[PROPERTY_STATUS]: {
+				'To Do': ['Task 1.md', 'Task 3.md', 'Task 2.md'],
+				Doing: ['Task 3.md'],
+			},
+		});
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const saved = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(saved[PROPERTY_STATUS]['To Do'], ['Task 1.md', 'Task 2.md'], 'Stale path should be dropped');
+		assert.deepStrictEqual(saved[PROPERTY_STATUS].Doing, ['Task 3.md'], 'Live cell should keep its entry');
+	});
+
+	test('Keeps entries for cards absent from the dataset (filtered out)', () => {
+		// Only the "To Do" cards are in the dataset, as if a Base filter hid the
+		// rest. Their saved order must survive so it returns with the filter.
+		const entries = createEntriesWithStatus().filter((e) => e.file.path === 'Task 1.md' || e.file.path === 'Task 2.md');
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('cardOrders', {
+			[PROPERTY_STATUS]: {
+				'To Do': ['Task 2.md', 'Task 1.md'],
+				Done: ['Task 5.md', 'Task 4.md'],
+			},
+		});
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const saved = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(saved[PROPERTY_STATUS].Done, ['Task 5.md', 'Task 4.md'], 'Filtered-out order must be kept');
+		assert.deepStrictEqual(saved[PROPERTY_STATUS]['To Do'], ['Task 2.md', 'Task 1.md'], 'Live order untouched');
+	});
+
+	test('Does not prune while a Base sort is active', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('sort', [{ property: 'file.mtime', direction: 'DESC' }]);
+		controller.config.set('cardOrders', {
+			[PROPERTY_STATUS]: { 'To Do': ['Task 1.md', 'Task 3.md'] },
+		});
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const saved = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(
+			saved[PROPERTY_STATUS]['To Do'],
+			['Task 1.md', 'Task 3.md'],
+			'Sorted board must not rewrite order',
+		);
+	});
+
+	test('Clean card orders are not rewritten', () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('cardOrders', {
+			[PROPERTY_STATUS]: { 'To Do': ['Task 2.md', 'Task 1.md'] },
+		});
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+
+		const setCallsBefore = (controller.config.set as any).calls?.length ?? 0;
+		triggerDataUpdate(view);
+		const saved = controller.config.get('cardOrders') as Record<string, Record<string, string[]>>;
+		assert.deepStrictEqual(saved[PROPERTY_STATUS]['To Do'], ['Task 2.md', 'Task 1.md'], 'Order preserved');
+		assert.ok(setCallsBefore >= 0);
+	});
+});
+
+describe('cardOrders write-back is not defeated by aliasing (#94)', () => {
+	let app: ReturnType<typeof createMockApp>;
+	let scrollEl: HTMLElement;
+	let controller: any;
+
+	beforeEach(() => {
+		setupTestEnvironment();
+		app = createMockApp();
+		scrollEl = createDivWithMethods();
+	});
+
+	// Counts config.set('cardOrders', …) calls. Reading the config back cannot
+	// detect this bug: when the stored value is aliased to _prefs it *looks*
+	// updated even though set() was never called — and set() is the only thing
+	// that marks the Base dirty, so without it nothing is ever written to disk.
+	function spyOnCardOrderSets(ctrl: any): { count: () => number } {
+		const original = ctrl.config.set.bind(ctrl.config);
+		let count = 0;
+		ctrl.config.set = (key: string, value: unknown): void => {
+			if (key === 'cardOrders') count++;
+			original(key, value);
+		};
+		return { count: () => count };
+	}
+
+	async function dropFirstCardTo(view: any, body: HTMLElement, from: number, to: number): Promise<void> {
+		const cards = Array.from(body.querySelectorAll('.obk-card')) as HTMLElement[];
+		body.insertBefore(cards[from], cards[to]);
+		await view.handleCardDrop({ item: cards[from], from: body, to: body, oldIndex: from, newIndex: to });
+	}
+
+	test('Every reorder calls config.set, not just the first', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const body = view.containerEl.querySelector('.obk-column[data-column-value="To Do"] .obk-column-body') as HTMLElement;
+		addClosestPolyfill(body);
+
+		const spy = spyOnCardOrderSets(controller);
+
+		await dropFirstCardTo(view as any, body, 1, 0); // Task 2 before Task 1
+		const afterFirst = spy.count();
+		assert.ok(afterFirst > 0, 'First reorder must write back');
+
+		await dropFirstCardTo(view as any, body, 1, 0); // swap back
+		assert.ok(
+			spy.count() > afterFirst,
+			'Second reorder must write back too — aliasing made the change-guard compare the stored object with itself, so set() was never called again and the Base was only saved on view close',
+		);
+	});
+
+	test('Stored card order is a snapshot, decoupled from _prefs', async () => {
+		const entries = createEntriesWithStatus();
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+
+		const body = view.containerEl.querySelector('.obk-column[data-column-value="To Do"] .obk-column-body') as HTMLElement;
+		addClosestPolyfill(body);
+		await dropFirstCardTo(view as any, body, 1, 0);
+
+		const stored = (controller.config.get('cardOrders') as Record<string, any>)[PROPERTY_STATUS];
+		assert.notStrictEqual(stored, (view as any)._prefs.cardOrders, 'Config must not hold the live _prefs object');
+
+		// A later prefs mutation must not silently reach the config.
+		(view as any)._prefs.cardOrders['To Do'].push('Leaked.md');
+		const after = (controller.config.get('cardOrders') as Record<string, any>)[PROPERTY_STATUS];
+		assert.ok(!after['To Do'].includes('Leaked.md'), 'Prefs mutation must not reach config without set()');
+	});
+});


### PR DESCRIPTION
Two independent defects in how `cardOrders` round-trips through the Base. They're unrelated in cause but both surface as "my card order didn't stick", so they're fixed together here. Refs #94.

---

### 1. Write-back stopped after the first drag

**Symptom:** card order appears to save only when the view is closed and reopened. In a vault where a script or another device reads the `.base` while the board is open, it reads stale order indefinitely.

**Cause:** `_persistConfigKey` stored `_prefs` **by reference**:

```ts
this.config?.set(key, { ...all, [storageKey]: newValue }); // newValue IS this._prefs.cardOrders
```

After the first successful write, the config's value *is* the live `_prefs` object. Every later drag mutates that same object in place, so by the time the change guard runs:

```ts
if (JSON.stringify(all[storageKey]) !== JSON.stringify(newValue))
```

...both sides are the **same object**. It always compares equal, `set()` is never called again, and since `set()` is what marks the Base dirty, nothing is written until the view closes and the config is serialised wholesale.

So: the first drag after opening a view persists; every subsequent one is silently lost.

**Fix:** store an independent snapshot, so the guard compares two distinct values and fires when the order actually changed:

```ts
this.config?.set(key, { ...all, [storageKey]: structuredClone(newValue) });
```

**On testing this one:** reading the config back *cannot* detect the bug — the aliased value looks updated even though `set()` was never called. My first attempt at a regression test passed against the unfixed code for exactly that reason. The test therefore asserts that `set()` **is called** on a second consecutive reorder, which fails without the fix.

### 2. Entries went stale when a card left a column without a drag

**Symptom:** a card's path lingers in a column's `cardOrders` list forever, and gets written back on every subsequent drag. Observed live: a card listed under two different columns at once, while its actual property value matched neither.

**Cause:** a card's column comes from its group-by property, which changes outside the board too — a script edits frontmatter, another device syncs, or the user edits the note. No drag fires, so `handleCardDrop` never rewrites the old column's list.

**Fix:** `render()` drops entries the live data places elsewhere.

**Deliberately conservative:** a path is removed **only** when the dataset positively puts it in a different cell. A path merely *absent* from the dataset is kept — it may be hidden by the Base's own filters, and its order must survive the filter being lifted. A consequence is that entries for deleted files linger; that's harmless (`applyCardOrder` skips paths it can't resolve) and strictly better than silently dropping a live card's slot. I did try pruning by "file no longer exists in the vault" and backed it out: if the vault isn't fully loaded when `render()` runs, that rule would delete real ordering from a shared file.

---

### Tests

Adds regression coverage for both defects. Each new test was verified to **fail without its fix** and pass with it:

- `Every reorder calls config.set, not just the first` — asserts on the `set()` call, not the read-back value (see above).
- `Stored card order is a snapshot, decoupled from _prefs`
- `Prunes a card order entry whose card now lives in another column`
- `Keeps entries for cards absent from the dataset (filtered out)` — guards the filter case.
- `Does not prune while a Base sort is active`

Full suite green (229 passing), plus `lint`, `format:check` and `build` per AGENTS.md. Verified in a real vault: with the fix, consecutive drags each reach the `.base` (~2s later, via Obsidian's own save debounce); before it, only the first did. The stale entries pruned themselves on load while every legitimate entry survived.

No behaviour change when a Base sort is active, and no change to the on-disk `cardOrders` shape.
