### PR TITLE
fix: quick add no longer creates a folder tree inside the configured column folder

### DIFF
--- a/src/components/quickAdd.ts
+++ b/src/components/quickAdd.ts
@@ -12,7 +12,7 @@ export interface QuickAddCtx {
 }
 
 export interface QuickAddCallbacks {
-	createFileForView: (path: string, setFrontmatter: (fm: Record<string, unknown>) => void) => Promise<void>;
+	createFileForView: (baseFileName: string, setFrontmatter: (fm: Record<string, unknown>) => void) => Promise<void>;
 }
 
 const CREATED_CARD_TIMEOUT_MS = 2000;
@@ -177,9 +177,8 @@ export async function createQuickAddCard(
 		new Notice(`Quick add folder not found: ${targetFolder}`);
 		return;
 	}
-	const fileNameToCreate = normalizePath(`${targetFolder}/${baseFileName}`);
 	const createdFilePaths = new Set(ctx.app.vault.getMarkdownFiles().map((file) => file.path));
-	const createdFilePromise = waitForCreatedMarkdownFile(ctx.app, createdFilePaths, fileNameToCreate);
+	const createdFilePromise = waitForCreatedMarkdownFile(ctx.app, createdFilePaths, baseFileName);
 
 	const setFrontmatter = (frontmatter: Record<string, unknown>): void => {
 		if (columnValue === UNCATEGORIZED_LABEL) {
@@ -197,7 +196,7 @@ export async function createQuickAddCard(
 	};
 
 	try {
-		await cb.createFileForView(fileNameToCreate, setFrontmatter);
+		await cb.createFileForView(baseFileName, setFrontmatter);
 		closeNativeNewItemPopover(ctx.doc);
 		await ensureCreatedCardInFolder(ctx.app, createdFilePaths, createdFilePromise, baseFileName, targetFolder);
 	} catch (error) {

--- a/src/kanbanView.ts
+++ b/src/kanbanView.ts
@@ -1138,7 +1138,7 @@ export class KanbanView extends BasesView {
 
 	private _buildQuickAddCallbacks(): QuickAddCallbacks {
 		return {
-			createFileForView: (path, setFm) => this.createFileForView(path, setFm),
+			createFileForView: (baseFileName, setFm) => this.createFileForView(baseFileName, setFm),
 		};
 	}
 

--- a/tests/kanbanView.test.ts
+++ b/tests/kanbanView.test.ts
@@ -371,7 +371,7 @@ describe('Data Rendering - Column Rendering', () => {
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
-			{ baseFileName: 'cards/New Task', frontmatter: { status: 'Doing' } },
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
 		]);
 	});
 
@@ -388,7 +388,7 @@ describe('Data Rendering - Column Rendering', () => {
 
 		await (view as any).createQuickAddCard('New Task', UNCATEGORIZED_LABEL, null);
 
-		assert.deepStrictEqual((view as any).createFileForViewCalls, [{ baseFileName: 'cards/New Task', frontmatter: {} }]);
+		assert.deepStrictEqual((view as any).createFileForViewCalls, [{ baseFileName: 'New Task', frontmatter: {} }]);
 	});
 
 	test('quick add sets both column and swimlane properties when used inside a lane', async () => {
@@ -410,7 +410,7 @@ describe('Data Rendering - Column Rendering', () => {
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
 			{
-				baseFileName: 'cards/New Lane Task',
+				baseFileName: 'New Lane Task',
 				frontmatter: { status: 'Doing', priority: 'High' },
 			},
 		]);
@@ -446,8 +446,42 @@ describe('Data Rendering - Column Rendering', () => {
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
-			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
 		]);
+		assert.deepStrictEqual(app.fileManager.renameFile.calls, []);
+	});
+
+	test('quick add asks Bases for a bare file name so no folder tree is created', async () => {
+		const entries = createEntriesWithStatus();
+		let markdownFiles = [createMockTFile('RootFolder/Tasks/maintenance-board.base')];
+
+		controller = createMockQueryController(entries, TEST_PROPERTIES);
+		controller.app = app;
+		controller.config.getAsPropertyId = () => PROPERTY_STATUS;
+		controller.config.set('quickAddFolder', 'RootFolder/Tasks');
+
+		(app.vault as any).getMarkdownFiles = () => markdownFiles;
+		(app.vault as any).getFolderByPath = (path: string) => (path === 'RootFolder/Tasks' ? { path, name: 'Tasks' } : null);
+		(app.vault as any).getAbstractFileByPath = (path: string) => markdownFiles.find((file) => file.path === path) ?? null;
+
+		const view = new KanbanView(controller, scrollEl);
+		setupKanbanViewWithApp(view, app);
+		triggerDataUpdate(view);
+		(view as any).createFileForView = async (
+			baseFileName: string,
+			frontmatterProcessor?: (frontmatter: Record<string, unknown>) => void,
+		) => {
+			const frontmatter: Record<string, unknown> = {};
+			frontmatterProcessor?.(frontmatter);
+			(view as any).createFileForViewCalls.push({ baseFileName, frontmatter });
+			markdownFiles = [...markdownFiles, createMockTFile(`RootFolder/Tasks/${baseFileName}.md`)];
+		};
+
+		await (view as any).createQuickAddCard('New Task', 'Doing', null);
+
+		const [call] = (view as any).createFileForViewCalls;
+		assert.strictEqual(call.baseFileName, 'New Task');
+		assert.ok(!call.baseFileName.includes('/'), 'Bases must receive a bare file name, not a path');
 		assert.deepStrictEqual(app.fileManager.renameFile.calls, []);
 	});
 
@@ -481,7 +515,7 @@ describe('Data Rendering - Column Rendering', () => {
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
-			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
 		]);
 		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
 	});
@@ -516,7 +550,7 @@ describe('Data Rendering - Column Rendering', () => {
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
-			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
 		]);
 		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
 	});
@@ -552,7 +586,7 @@ describe('Data Rendering - Column Rendering', () => {
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
-			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
 		]);
 		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task 1.md']);
 	});
@@ -596,7 +630,7 @@ describe('Data Rendering - Column Rendering', () => {
 		await (view as any).createQuickAddCard('New Task', 'Doing', null);
 
 		assert.deepStrictEqual((view as any).createFileForViewCalls, [
-			{ baseFileName: 'energy/New Task', frontmatter: { status: 'Doing' } },
+			{ baseFileName: 'New Task', frontmatter: { status: 'Doing' } },
 		]);
 		assert.deepStrictEqual(app.fileManager.renameFile.calls[0], [createdFile, 'energy/New Task.md']);
 	});


### PR DESCRIPTION
Closes #105

## Root cause

`BasesView.createFileForView` takes a *base file name*, not a path. Obsidian resolves the parent folder itself and appends the string you pass — so slashes in the name become real nested folders.

Quick add has been passing a full path since #66:

```ts
const fileNameToCreate = normalizePath(`${targetFolder}/${baseFileName}`);
await cb.createFileForView(fileNameToCreate, setFrontmatter);
```

I think this explains the behavior described as opaque in #78 ("sometimes this works and sometimes it doesn't"). It isn't that path support is sometimes present — **it's that the resolved parent folder varies**:

- If the resolved parent is the **vault root**, `createFileForView("energy/New Task")` produces exactly `energy/New Task.md`. Path support appears to work, and no rename is needed. This is presumably the setup #66 was validated against.
- If the resolved parent is **any other folder**, the same call creates the folder tree underneath it.

In #105 the resolved parent happened to *be* the configured folder, so the result was:

```text
RootFolder/Tasks/            <- configured "Add card to column folder"
├── New Task.md
└── RootFolder/Tasks/        <- created from the path passed to createFileForView
```

`ensureCreatedCardInFolder` from #80 then correctly detected the note was in the wrong place and moved it out — which is why the card always looked right while an empty folder tree accumulated in the vault on every quick add.

## Fix

Pass the sanitized bare name and let `ensureCreatedCardInFolder` handle placement — the branch it already took whenever Bases ignored the configured folder.

This deliberately keeps #80's create-then-verify-then-move-only-if-needed structure. It is **not** a revert to the pre-#66 two-step: the only change is that we stop passing a path to a parameter that isn't one. `sanitizeBaseFileName` strips `/` and `\`, so no path can reach the API.

| Resolved parent | Before | After |
|---|---|---|
| Vault root, folder `energy` | `energy/New Task.md`, no rename | root, then renamed into `energy` |
| Configured folder itself | duplicate folder tree, note moved out (#105) | correct on creation, **no rename** |
| Base file folder, e.g. `dashboards` | created then moved, may leave stray folders | created then moved, no stray folders |

## Trade-off and regression risk

Worth stating plainly: in the vault-root case this **introduces a rename where #80 had none**, and the create-then-rename lifecycle is what caused #58 (the Self-hosted LiveSync race producing `Task 1.md`). Users for whom 0.10.2 currently works without a rename could see that race return.

I think the trade is still right:

- The folder pollution is unconditional and permanent — every quick add leaves directories behind, in every affected vault.
- #58 is a race with a specific third-party sync plugin, and it predates #66.
- #80 already treats the move as a normal code path; this makes the reliable branch the only branch rather than reviving a discarded design.

But it is a judgement call about which failure mode is worse, so I'd rather flag it than have it found in review.

## Possible follow-up

The suggestion in #78 — `vault.create(path, '')` followed by `fileManager.processFrontMatter(file, fn)` — would place the note exactly, one step, no folder creation and no rename, which would address #58, #61, #78 and #105 together. The cost is losing whatever Bases derives from the view's filters, since the plugin would own frontmatter entirely. Out of scope here, but it seems like the real exit from this class of bug.

## Verification criteria

Manual testing in a live vault on Obsidian 1.13.7, with **Settings → Files and links → Default location for new notes** resolving to the default `Vault Folder` (to let plugin take control)

Tests:

- Updated 7 existing assertions that encoded the old behavior (expected `'cards/New Task'` / `'energy/New Task'`, now `'New Task'`). These would have passed indefinitely while the plugin created folder trees, since nothing asserted what was actually passed to the API.
- Added a regression test, "quick add asks Bases for a bare file name so no folder tree is created", which mocks `createFileForView` the way Obsidian behaves — resolving the parent to the same folder configured for quick add — and asserts the name passed contains no `/` and that no rename is required.
- Existing coverage still passes: Bases creating directly in the configured folder (no move), creating elsewhere (moved), collisions (`New Task 1.md`), and async creation via the vault `create` event.
- 224 tests passing. `lint`, `format:check`, `typecheck` and `build` all clean.

Edge cases considered:

- Titles containing `/` or `\` are already stripped by `sanitizeBaseFileName`, so they cannot reintroduce nested folders.
- `waitForCreatedMarkdownFile` / `getCreatedMarkdownFile` already did `baseFileName.split('/').pop()`, so they behave identically with a bare name.

No version bump — left to the maintainer.